### PR TITLE
MWPW-141119: Change default pricing for Africa site to fix broken prices/promos

### DIFF
--- a/commerce/src/settings.js
+++ b/commerce/src/settings.js
@@ -30,7 +30,7 @@ const GeoMap = {
     la: 'DO_es',
     mx: 'MX_es',
     pe: 'PE_es',
-    africa: 'ZA_en',
+    africa: 'MU_en',
     dk: 'DK_da',
     de: 'DE_de',
     ee: 'EE_et',

--- a/commerce/test/settings.test.js
+++ b/commerce/test/settings.test.js
@@ -114,7 +114,7 @@ describe('getSettings', () => {
 
     [
         { prefix: '/ar', expectedLocale: 'es_AR' },
-        { prefix: '/africa', expectedLocale: 'en_ZA' },
+        { prefix: '/africa', expectedLocale: 'en_MU' },
         { prefix: '', expectedLocale: 'en_US' },
         { prefix: '/ae_ar', expectedLocale: 'ar_AE' },
     ].forEach(({ prefix, expectedLocale }) => {


### PR DESCRIPTION
For Africa: configure default price to Mauritius (mu) showing USD pricing excluding VAT

Fix #MWPW-141119

URL for testing:

- https://mwpw-141119--milo--rahulgupta999.hlx.page/africa/drafts/mili/promo-placeholders

