### PR TITLE
MWPW-135160: merch-card (plans, key-apps)

### DIFF
--- a/web-components/src/global.css.js
+++ b/web-components/src/global.css.js
@@ -25,6 +25,7 @@ styles.innerHTML = `
 
     /* responsive width */
     --consonant-merch-card-mobile-width: 300px;
+    --consonant-merch-card-tablet-wide-width: 700px;
 
     /* spacing */
     --consonant-merch-spacing-xxxs: 4px;

--- a/web-components/src/merch-card.css.js
+++ b/web-components/src/merch-card.css.js
@@ -382,8 +382,10 @@ export const sizeStyles = () => {
         @media screen and ${unsafeCSS(TABLET_UP)} {
             :host([size='wide']),
             :host([size='super-wide']) {
-                grid-column: span 2;
+                grid-column: span 3;
                 width: 100%;
+                max-width: var(--consonant-merch-card-tablet-wide-width);
+                margin: 0 auto;
             }
         }
 


### PR DESCRIPTION
Adds ability to display inline mnemonic list block inside merch card. This PR handles changes for the super-wide plans card.
![3b98db46-763e-47e3-94ee-c0bfba91aa0d](https://github.com/adobecom/mas/assets/1179549/bcbc4ba2-3d1a-4d0c-9fa8-80b1efab017f)


Resolves: MWPW-135160


Test URLs:
- Before: https://main--milo--axelcureno.hlx.page/drafts/axel/mwpw-135160?martech=off
- After: https://mwpw-135160--milo--axelcureno.hlx.page/drafts/axel/mwpw-135160?martech=off
