### PR TITLE
MWPW-143069 [Milo OST] Tax label enhancements

### DIFF
--- a/commerce/src/index.js
+++ b/commerce/src/index.js
@@ -11,7 +11,7 @@ import {
     WcsPlanType,
     applyPlanType,
 } from './external.js';
-import { InlinePrice } from './inline-price.js';
+import { InlinePrice, resolvePriceTaxFlags } from './inline-price.js';
 import { Log } from './log.js';
 import { initService, resetService } from './service.js';
 import { getLocaleSettings, getSettings } from './settings.js';
@@ -34,4 +34,5 @@ export {
     getSettings,
     initService as init,
     resetService as reset,
+    resolvePriceTaxFlags,
 };

--- a/commerce/test/mocks/literals.json
+++ b/commerce/test/mocks/literals.json
@@ -34,7 +34,7 @@
             "freeLabel": "Безплатно",
             "freeAriaLabel": "Безплатно",
             "taxExclusiveLabel": "{taxTerm, select, GST {excl. GST} VAT {excl. VAT} TAX {excl. tax} IVA {excl. IVA} SST {excl. SST} KDV {excl. KDV} other {}}",
-            "taxInclusiveLabel": "{incl. VAT} TAX {incl. tax} IVA {incl. IVA} SST {incl. SST} KDV {incl. KDV} other {}}",
+            "taxInclusiveLabel": "{taxTerm, select, GST {incl. GST} VAT {incl. VAT} TAX {incl. tax} IVA {incl. IVA} SST {incl. SST} KDV {incl. KDV} other {}}",
             "alternativePriceAriaLabel": "Алтернативно на {alternativePrice}",
             "strikethroughAriaLabel": "Редовно на {strikethroughPrice}"
         },

--- a/commerce/test/mocks/offers.json
+++ b/commerce/test/mocks/offers.json
@@ -917,11 +917,10 @@
             "offerId": "DAC628518DDD843D4D19A8BF7D8FF1FA",
             "priceDetails": {
                 "price": 1.99,
-                "priceWithoutTax": 0.0,
-                "priceWithoutDiscountAndTax": 1.99,
+                "priceWithoutTax": 1.59,
                 "usePrecision": true,
                 "formatString": "'US$'#,##0.00",
-                "taxDisplay": "TAX_EXCLUSIVE",
+                "taxDisplay": "TAX_INCLUSIVE_DETAILS",
                 "taxTerm": "TAX"
             },
             "productArrangementCode": "ccle_direct_indirect_team",
@@ -947,11 +946,10 @@
             "offerId": "DAC628518DDD843D4D19A8BF7D8FF1FB",
             "priceDetails": {
                 "price": 1.99,
-                "priceWithoutTax": 0.0,
-                "priceWithoutDiscountAndTax": 1.99,
+                "priceWithoutTax": 1.59,
                 "usePrecision": true,
                 "formatString": "'US$'#,##0.00",
-                "taxDisplay": "TAX_EXCLUSIVE",
+                "taxDisplay": "TAX_INCLUSIVE_DETAILS",
                 "taxTerm": "TAX"
             },
             "productArrangementCode": "ccle_direct_indirect_team",
@@ -977,11 +975,10 @@
             "offerId": "DAC628518DDD843D4D19A8BF7D8FF1FC",
             "priceDetails": {
                 "price": 1.99,
-                "priceWithoutTax": 0.0,
-                "priceWithoutDiscountAndTax": 1.99,
+                "priceWithoutTax": 1.59,
                 "usePrecision": true,
                 "formatString": "'US$'#,##0.00",
-                "taxDisplay": "TAX_EXCLUSIVE",
+                "taxDisplay": "TAX_INCLUSIVE_DETAILS",
                 "taxTerm": "TAX"
             },
             "productArrangementCode": "ccle_direct_indirect_team",
@@ -1007,11 +1004,10 @@
             "offerId": "DAC628518DDD843D4D19A8BF7D8FF1FD",
             "priceDetails": {
                 "price": 1.99,
-                "priceWithoutTax": 0.0,
-                "priceWithoutDiscountAndTax": 1.99,
+                "priceWithoutTax": 1.59,
                 "usePrecision": true,
                 "formatString": "'US$'#,##0.00",
-                "taxDisplay": "TAX_EXCLUSIVE",
+                "taxDisplay": "TAX_INCLUSIVE_DETAILS",
                 "taxTerm": "TAX"
             },
             "productArrangementCode": "ccle_direct_indirect_team",

--- a/commerce/test/price.test.js
+++ b/commerce/test/price.test.js
@@ -292,351 +292,351 @@ describe('class "InlinePrice"', () => {
         const TESTS = [
             {
                 locale: 'AE_ar',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'AE_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'ZA_en',
-                expected: [true, true, false, false]
+                expected: [[true, false], [true, false], [false, false], [false, false]]
             },
             {
                 locale: 'AT_de',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, false], [true, false], [true, true]]
             },
             {
                 locale: 'BE_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'BE_fr',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'BE_nl',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'BG_bg',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'CH_de',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'CH_fr',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'CH_it',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'AZ_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'AZ_ru',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'CZ_cs',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'DE_de',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'DK_da',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'EE_et',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'EG_ar',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'EG_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'ES_es',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'FI_fi',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'FR_fr',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'GR_el',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'GR_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'HU_hu',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'IE_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'IL_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'IL_iw',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'IT_it',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'KW_ar',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'KW_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'LT_lt',
-                expected: [true, true, true, false]
+                expected: [[true, false], [true, true], [true, false], [false, false]]
             },
             {
                 locale: 'LU_de',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'LU_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'LU_fr',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'LV_lv',
-                expected: [true, true, true, false]
+                expected: [[true, false], [true, true], [true, false], [false, false]]
             },
             {
                 locale: 'DZ_ar',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'DZ_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'NG_en',
-                expected: [true, true, false, false]
+                expected: [[true, false], [true, false], [false, false], [false, false]]
             },
             {
                 locale: 'NL_nl',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'NO_nb',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'PL_pl',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'PT_pt',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'QA_ar',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'QA_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'RO_ro',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'RU_ru',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'SA_ar',
-                expected: [true, false, false, false]
+                expected: [[true, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'SA_en',
-                expected: [true, false, true, false]
+                expected: [[true, false], [false, false], [true, false], [false, false]]
             },
             {
                 locale: 'SE_sv',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'SI_sl',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'SK_sk',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'TR_tr',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'UA_uk',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'ZA_en',
-                expected: [true, true, false, false]
+                expected: [[true, false], [true, false], [false, false], [false, false]]
             },
             {
                 locale: 'AU_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, false], [true, false], [true, false]]
             },
             {
                 locale: 'HK_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'ID_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'ID_in',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'IN_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'IN_hi',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'JP_ja',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, false], [true, false], [true, false]]
             },
             {
                 locale: 'KR_ko',
-                expected: [true, true, false, true]
+                expected: [[true, false], [true, true], [false, false], [true, true]]
             },
             {
                 locale: 'MY_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'MY_ms',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, true], [true, false], [true, true]]
             },
             {
                 locale: 'NZ_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, false], [true, false], [true, false]]
             },
             {
                 locale: 'PH_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'PH_fil',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'SG_en',
-                expected: [true, false, true, true]
+                expected: [[true, false], [false, false], [true, false], [true, false]]
             },
             {
                 locale: 'TH_en',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, false], [true, false], [true, false]]
             },
             {
                 locale: 'TH_th',
-                expected: [true, true, true, true]
+                expected: [[true, false], [true, false], [true, false], [true, false]]
             },
             {
                 locale: 'VN_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'VN_vi',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'AR_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'BR_pt',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'CA_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'CA_fr',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'CL_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'CO_es',
-                expected: [false, true, false, false]
+                expected: [[false, false], [true, true], [false, false], [false, false]]
             },
             {
                 locale: 'CR_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'EC_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'GT_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'LA_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'MX_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'PE_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'PR_es',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
             {
                 locale: 'US_en',
-                expected: [false, false, false, false]
+                expected: [[false, false], [false, false], [false, false], [false, false]]
             },
         ];
 
@@ -647,11 +647,18 @@ describe('class "InlinePrice"', () => {
                     const service = await initService(config, true);
                     const inlinePrice = mockInlinePrice(segment);
                     inlinePrice.removeAttribute('data-display-tax');
+                    inlinePrice.removeAttribute('data-force-tax-exclusive');
                     await inlinePrice.onceSettled();
                     const priceTaxElement = inlinePrice.querySelector('.price-tax-inclusivity');
-                    if (test.expected[index]) {
-                        const taxExclusiveLabel = service.literals.price.taxExclusiveLabel;
-                        const taxLabel = taxExclusiveLabel.match(/TAX \{(.*?)\}/)[1]
+                    const priceDecimals = inlinePrice.querySelector('.price-decimals').textContent;
+                    if (test.expected[index][0]) {
+                        let taxInclExclLabel
+                        if (priceDecimals === '59') { // forceTaxExclusive: true
+                            taxInclExclLabel = service.literals.price.taxExclusiveLabel;
+                        } else {
+                            taxInclExclLabel = service.literals.price.taxInclusiveLabel;
+                        }
+                        const taxLabel = taxInclExclLabel.match(/TAX \{(.*?)\}/)[1]
                         expect(priceTaxElement.textContent).to.equal(taxLabel);
                     } else {
                         expect(priceTaxElement.classList.contains('disabled')).to.be.true;


### PR DESCRIPTION
Introduced matrix with default values for OST flags "Tax label" and "Include tax" per locale and offer segment.
Method `resolvePriceTaxFlags` exported to be called from OST to get those values for a specific offer.

Fix # [MWPW-143069](https://jira.corp.adobe.com/browse/MWPW-143069)

Test URLs:
- Before: https://main--mas--adobecom.hlx.live
- After: https://mwpw143069--mas--bozojovicic.hlx.live
