### PR TITLE
MWPW-152283: add acom wcs endpoint

### DIFF
--- a/commerce/src/defaults.js
+++ b/commerce/src/defaults.js
@@ -22,6 +22,7 @@ export const Defaults = Object.freeze({
     entitlement: false,
     extraOptions: {},
     modal: false,
+    upgrade: false,
     promotionCode: '',
     quantity: 1,
     wcsApiKey: 'wcms-commerce-ims-ro-user-milo',

--- a/commerce/src/defaults.js
+++ b/commerce/src/defaults.js
@@ -22,7 +22,6 @@ export const Defaults = Object.freeze({
     entitlement: false,
     extraOptions: {},
     modal: false,
-    upgrade: false,
     promotionCode: '',
     quantity: 1,
     wcsApiKey: 'wcms-commerce-ims-ro-user-milo',

--- a/commerce/src/index.d.ts
+++ b/commerce/src/index.d.ts
@@ -576,6 +576,7 @@ declare global {
                 wcsBufferDelay: number;
                 wcsBufferLimit: number;
                 wcsEnv: Environment;
+                domainSwitch: boolean;
             }
         }
     }

--- a/commerce/src/settings.js
+++ b/commerce/src/settings.js
@@ -180,7 +180,6 @@ function getSettings(config = {}) {
         Defaults.entitlement
     );
     const modal = toBoolean(getParameter('modal', commerce), Defaults.modal);
-    const upgrade = toBoolean(getParameter('upgrade', commerce), Defaults.upgrade);
     const forceTaxExclusive = toBoolean(
         getParameter('forceTaxExclusive', commerce),
         Defaults.forceTaxExclusive
@@ -219,7 +218,6 @@ function getSettings(config = {}) {
         entitlement,
         extraOptions: Defaults.extraOptions,
         modal,
-        upgrade,
         env,
         forceTaxExclusive,
         priceLiteralsURL: commerce.priceLiteralsURL,

--- a/commerce/src/settings.js
+++ b/commerce/src/settings.js
@@ -180,6 +180,7 @@ function getSettings(config = {}) {
         Defaults.entitlement
     );
     const modal = toBoolean(getParameter('modal', commerce), Defaults.modal);
+    const upgrade = toBoolean(getParameter('upgrade', commerce), Defaults.upgrade);
     const forceTaxExclusive = toBoolean(
         getParameter('forceTaxExclusive', commerce),
         Defaults.forceTaxExclusive
@@ -204,6 +205,7 @@ function getSettings(config = {}) {
         getParameter('wcsBufferLimit', commerce),
         Defaults.wcsBufferLimit
     );
+    const domainSwitch = toBoolean(getParameter('domain.switch', commerce), false);
 
     return {
         ...getLocaleSettings({ locale }),
@@ -217,6 +219,7 @@ function getSettings(config = {}) {
         entitlement,
         extraOptions: Defaults.extraOptions,
         modal,
+        upgrade,
         env,
         forceTaxExclusive,
         priceLiteralsURL: commerce.priceLiteralsURL,
@@ -228,6 +231,7 @@ function getSettings(config = {}) {
         wcsBufferLimit,
         wcsEnv: env === Env.STAGE ? WcsEnv.STAGE : WcsEnv.PRODUCTION,
         landscape,
+        domainSwitch,
     };
 }
 

--- a/commerce/src/wcs.js
+++ b/commerce/src/wcs.js
@@ -24,6 +24,7 @@ import { Log } from './log.js';
 const WcsBaseUrl = {
     [Env.PRODUCTION]: 'https://wcs.adobe.com',
     [Env.STAGE]: 'https://wcs.stage.adobe.com',
+    ['STAGE_ACOM']: 'https://www.stage.adobe.com',
 };
 
 /**
@@ -32,12 +33,12 @@ const WcsBaseUrl = {
  */
 export function Wcs({ settings }) {
     const log = Log.module('wcs');
-    const { env, wcsApiKey: apiKey } = settings;
-
+    const { env, domainSwitch, wcsApiKey: apiKey } = settings;
+    const baseUrl = domainSwitch ? WcsBaseUrl['STAGE_ACOM'] : WcsBaseUrl[env];
     // Create @pandora Wcs client.
     const fetchOptions = {
         apiKey,
-        baseUrl: WcsBaseUrl[env],
+        baseUrl,
         fetch: window.fetch.bind(window),
     };
     const getWcsOffers = webCommerceArtifact(fetchOptions);

--- a/commerce/src/wcs.js
+++ b/commerce/src/wcs.js
@@ -20,11 +20,12 @@ import { Log } from './log.js';
  *  reject: (reason: Error) => void
  * }>} WcsPromises
  */
-
+const ACOM = '_acom';
 const WcsBaseUrl = {
     [Env.PRODUCTION]: 'https://wcs.adobe.com',
     [Env.STAGE]: 'https://wcs.stage.adobe.com',
-    ['STAGE_ACOM']: 'https://www.stage.adobe.com',
+    [Env.PRODUCTION + ACOM]: 'https://www.adobe.com',
+    [Env.STAGE + ACOM]: 'https://www.stage.adobe.com',
 };
 
 /**
@@ -34,7 +35,7 @@ const WcsBaseUrl = {
 export function Wcs({ settings }) {
     const log = Log.module('wcs');
     const { env, domainSwitch, wcsApiKey: apiKey } = settings;
-    const baseUrl = domainSwitch ? WcsBaseUrl['STAGE_ACOM'] : WcsBaseUrl[env];
+    const baseUrl = domainSwitch ? WcsBaseUrl[env + ACOM] : WcsBaseUrl[env];
     // Create @pandora Wcs client.
     const fetchOptions = {
         apiKey,


### PR DESCRIPTION
Resolve https://jira.corp.adobe.com/browse/MWPW-152283

Oversimplified ability to test acom wcs domain performance (should take away OPTIONS request from stage.adobe.com)
To see this in action add `?commerce.env=STAGE&domain.switch=true`


<img width="1567" alt="image" src="https://github.com/adobecom/mas/assets/6617234/2fc0a906-784e-42fe-973c-d121179288e1">


Test URLs:
- Before: https://main--milo--adobecom.hlx.page/drafts/mili/promo-placeholders?martech=off&commerce.env=STAGE&domain.switch=true
- After: https://mwpw-152283--milo--adobecom.hlx.page/drafts/mili/promo-placeholders?martech=off&commerce.env=STAGE&domain.switch=true
