### PR TITLE
MWPW-148002: Set strikethrough price font size to 14px on mini-compare card variation

### DIFF
--- a/web-components/src/global.css.js
+++ b/web-components/src/global.css.js
@@ -396,7 +396,7 @@ merch-card[variant="mini-compare-chart"] [is="inline-price"] {
 }
 
 merch-card[variant="mini-compare-chart"] span.placeholder-resolved[data-template="strikethrough"] {
-    font-size: var(--consonant-merch-card-body-m-font-size);
+    font-size: var(--type-body-xs-size);
     font-weight: 500;
 }
 
@@ -496,10 +496,6 @@ merch-card[variant="mini-compare-chart"] .footer-row-cell-description a {
 
     merch-card[variant="mini-compare-chart"] [slot="heading-m-price"]:has(+ [slot="footer"]) {
         padding-bottom: 0;
-    }
-
-    merch-card[variant="mini-compare-chart"] span.placeholder-resolved[data-template="strikethrough"] {
-        font-size: var(--consonant-merch-card-body-xs-font-size);
     }
 
     merch-card[variant="mini-compare-chart"] [slot="price-commitment"] {


### PR DESCRIPTION
In the previous PR for this task the strikethrough price font size was set to 14px for all card variants except for mini-compare (by mistake).
In this PR we change the strikethrough price font size to 14px on mini-compare card variation as well (for all screen sizes).

Resolves: [MWPW-148002](https://jira.corp.adobe.com/browse/MWPW-148002)

Test URLs:

Before: https://main--cc--adobecom.hlx.live/creativecloud?martech=off (in Students and Teachers tab)
After: https://main--cc--adobecom.hlx.live/creativecloud?martech=off&milolibs=mwpw-148002-mini-compare-strikethrough-price--milo--mirafedas (in Students and Teachers tab)