### PR TITLE
MWPW-153657: Set the strikethrough price font size to 14px only in merch cards

### DIFF
--- a/web-components/src/global.css.js
+++ b/web-components/src/global.css.js
@@ -395,11 +395,6 @@ merch-card[variant="mini-compare-chart"] [is="inline-price"] {
     min-width: 1px;
 }
 
-merch-card[variant="mini-compare-chart"] span.placeholder-resolved[data-template="strikethrough"] {
-    font-size: var(--consonant-merch-card-body-m-font-size);
-    font-weight: 500;
-}
-
 merch-card[variant="mini-compare-chart"] [slot="price-commitment"] {
     font-size: var(--consonant-merch-card-body-xs-font-size);
     padding: 0 var(--consonant-merch-spacing-s);
@@ -503,10 +498,6 @@ merch-card[variant="mini-compare-chart"] .footer-row-cell-description a {
 
     merch-card[variant="mini-compare-chart"] [slot="heading-m-price"]:has(+ [slot="footer"]) {
         padding-bottom: 0;
-    }
-
-    merch-card[variant="mini-compare-chart"] span.placeholder-resolved[data-template="strikethrough"] {
-        font-size: var(--consonant-merch-card-body-xs-font-size);
     }
 
     html[lang="he"] merch-card[variant="mini-compare-chart"] [is="inline-price"] .price-recurrence::before {
@@ -982,6 +973,12 @@ merch-card .footer-row-cell:nth-child(8) {
 
 span[is="inline-price"][data-template='strikethrough'] {
     text-decoration: line-through;
+}
+
+merch-card span.placeholder-resolved[data-template='strikethrough'],
+merch-card span.price.price-strikethrough {
+  font-size: var(--consonant-merch-card-body-xs-font-size);
+  font-weight: normal;
 }
 
 /* merch-offer-select */


### PR DESCRIPTION
On the corresponding Milo PR we set the strikethrough price font size to 14px for all merch cards, including the mini-compare-chart variant, so in this PR we are removing the CSS rules to avoid overwriting the ones we set in Milo.

[MWPW-153657](https://jira.corp.adobe.com/browse/MWPW-153657)

Test URLs:
- DC: https://main--dc--adobecom.hlx.page/drafts/steenmeyer/acrobat-pricing-samples/acrobat-business-merch-card-product
- Milo: https://main--milo--adobecom.hlx.page/docs/authoring/commerce/merch-card-product
- Mini-compare variation: https://main--milo--adobecom.hlx.live/drafts/axel/mini-compare-chart

After:
- DC: https://main--dc--adobecom.hlx.page/drafts/steenmeyer/acrobat-pricing-samples/acrobat-business-merch-card-product?milolibs=mwpw-153657-strikethrough-price--milo--mirafedas
- Milo: [https://mwpw-153657-strikethrough-price--milo--mirafedas.hlx.page/docs/authoring/commerce/merch-card-product\](https://mwpw-153657-strikethrough-price--milo--mirafedas.hlx.page/docs/authoring/commerce/merch-card-product%5C)
- Mini-compare variation: https://mwpw-153657-strikethrough-price--milo--mirafedas.hlx.page/drafts/axel/mini-compare-chart