### PR TITLE
MWPW-149125 and MWPW-147035

### DIFF
--- a/web-components/src/merch-stock.js
+++ b/web-components/src/merch-stock.js
@@ -1,7 +1,5 @@
 import { LitElement, css, html } from 'lit';
 import { EVENT_MERCH_STOCK_CHANGE } from './constants.js';
-import { MatchMediaController } from '@spectrum-web-components/reactive-controllers/src/MatchMedia.js';
-import { MOBILE_LANDSCAPE } from './media.js';
 
 export class MerchStock extends LitElement {
     static styles = [
@@ -34,8 +32,6 @@ export class MerchStock extends LitElement {
     };
 
     checked = false;
-
-    #mobile = new MatchMediaController(this, MOBILE_LANDSCAPE);
 
     constructor() {
         super();
@@ -71,7 +67,6 @@ export class MerchStock extends LitElement {
 
     render() {
         if (!this.planType) return;
-        if (this.#mobile.matches) return;
         return html`
             <sp-checkbox
                 size="s"

--- a/web-components/src/merch-subscription-panel.js
+++ b/web-components/src/merch-subscription-panel.js
@@ -7,7 +7,7 @@ import {
     EVENT_MERCH_STOCK_CHANGE,
     EVENT_OFFER_SELECTED,
 } from './constants.js';
-import { TABLET_DOWN } from './media.js';
+import { TABLET_DOWN, MOBILE_LANDSCAPE } from './media.js';
 
 class MerchSubscriptionPanel extends LitElement {
     static styles = [styles];
@@ -21,6 +21,7 @@ class MerchSubscriptionPanel extends LitElement {
     continueText = 'Continue';
 
     #mobileAndTablet = new MatchMediaController(this, TABLET_DOWN);
+    #mobile = new MatchMediaController(this, MOBILE_LANDSCAPE);
 
     constructor() {
         super();
@@ -125,7 +126,7 @@ class MerchSubscriptionPanel extends LitElement {
     }
 
     handleOfferSelect(event) {
-        if (this.offerSelect?.stock) {
+        if (this.stock && this.offerSelect?.stock) {
             this.stock.planType = event.detail.planType;
         }
         this.requestUpdate();
@@ -181,6 +182,7 @@ class MerchSubscriptionPanel extends LitElement {
     }
 
     get stock() {
+        if (this.#mobile.matches) return null;
         return this.querySelector('merch-stock');
     }
 

--- a/web-components/src/merch-twp-d2p.js
+++ b/web-components/src/merch-twp-d2p.js
@@ -216,7 +216,7 @@ export class MerchTwpD2P extends LitElement {
         this.singleCard = card;
     }
 
-    unSelectSingleCard() {
+    async unSelectSingleCard() {
         if (!this.singleCard) return;
         this.singleCard.setAttribute(
             'slot',
@@ -224,7 +224,11 @@ export class MerchTwpD2P extends LitElement {
         );
         this.singleCard.removeAttribute('data-slot');
         this.step = 1;
+        const cardToBeSelected = this.singleCard;
         this.singleCard = undefined;
+        await this.tabElement?.updateComplete;
+        this.selectedTabPanel.card = cardToBeSelected;
+        this.selectCard(cardToBeSelected, true);
     }
 
     handleContinue() {
@@ -370,7 +374,9 @@ export class MerchTwpD2P extends LitElement {
     }
 
     get preselectedCardId() {
-        const preselectedCardIds = parseState()['select-cards']?.split(',').reduce((res, item) => {
+        const params = new URLSearchParams(window.location.search);
+        const selectCards = params.get('select-cards');
+        const preselectedCardIds = selectCards?.split(',').reduce((res, item) => {
             const formattedItem = decodeURIComponent(item.trim().toLowerCase());
             formattedItem && res.push(formattedItem);
             return res;
@@ -405,7 +411,7 @@ export class MerchTwpD2P extends LitElement {
             if (selectedCard) {
                 selectedCard.selected = undefined;
             }
-            selectedCard = this.cardToBePreselected || card;
+            selectedCard = !selectedCard && this.cardToBePreselected ? this.cardToBePreselected : card;
             selectedCard.selected = true;
             if (tabPanel) {
                 tabPanel.card = selectedCard;

--- a/web-components/test/merch-twp-d2p.test.html.js
+++ b/web-components/test/merch-twp-d2p.test.html.js
@@ -161,7 +161,7 @@ runTests(async () => {
         });
 
         it('preselects the card from hash', async () => {
-            document.location.hash = 'select-cards=photoshop&creat&creati';
+            document.location.search = 'select-cards=photoshop&creat&creati';
             await applyTemplate('cci-footer,preselect-card', false);
             const merchCard = document.querySelector(
                 'merch-card[aria-selected]'


### PR DESCRIPTION
These are 2 TWP tickets reported long time ago but I could not implement them before TWP code in Milo is merged to Stage. [MWPW-147035](https://jira.corp.adobe.com/browse/MWPW-147035) is also blocked by one bug in TWP in Milo code (Card title not displayed) but I will provide the fix for that bug in Milo PR after this PR is merged.

Fix # [MWPW-149125](https://jira.corp.adobe.com/browse/MWPW-149125) Suppress Stock Checkbox on all modals for mobile users only
Fix # [MWPW-147035](https://jira.corp.adobe.com/browse/MWPW-147035) Ability to deeplink into a card or tab within the modal

Test URLs:
- Before: https://main--mas--adobecom.hlx.live/
- After: https://mwpw147035--mas--bozojovicic.hlx.live
