### PR TITLE
MWPW-147716: Renamed isIosDevice > IS_IOS

### DIFF
--- a/web-components/src/bodyScrollLock.js
+++ b/web-components/src/bodyScrollLock.js
@@ -3,19 +3,13 @@ Enables body scroll locking (for iOS Mobile and Tablet, Android, desktop Safari/
 Usage example: when opening a modal, disable body scroll by calling enableBodyScroll, and enable it back when closing the modal by calling disableBodyScroll.
 */
 
-const isIosDevice =
-    typeof window !== 'undefined' &&
-    window.navigator &&
-    window.navigator.platform &&
-    (/iP(ad|hone|od)/.test(window.navigator.platform) ||
-        (window.navigator.platform === 'MacIntel' &&
-            window.navigator.maxTouchPoints > 1));
+const IS_IOS = /iP(ad|hone|od)/.test(window?.navigator?.platform) || (window?.navigator?.platform === 'MacIntel' && window.navigator.maxTouchPoints > 1);
 let documentListenerAdded = false;
 let previousBodyOverflowSetting;
 
 export const disableBodyScroll = (targetElement) => {
     if (!targetElement) return;
-    if (isIosDevice) {
+    if (IS_IOS) {
         document.body.style.position = 'fixed';
         targetElement.ontouchmove = (event) => {
             if (event.targetTouches.length === 1) {
@@ -34,7 +28,7 @@ export const disableBodyScroll = (targetElement) => {
 
 export const enableBodyScroll = (targetElement) => {
     if (!targetElement) return;
-    if (isIosDevice) {
+    if (IS_IOS) {
         targetElement.ontouchstart = null;
         targetElement.ontouchmove = null;
         document.body.style.position = '';

--- a/web-components/src/bodyScrollLock.js
+++ b/web-components/src/bodyScrollLock.js
@@ -3,13 +3,13 @@ Enables body scroll locking (for iOS Mobile and Tablet, Android, desktop Safari/
 Usage example: when opening a modal, disable body scroll by calling enableBodyScroll, and enable it back when closing the modal by calling disableBodyScroll.
 */
 
-const IS_IOS = /iP(ad|hone|od)/.test(window?.navigator?.platform) || (window?.navigator?.platform === 'MacIntel' && window.navigator.maxTouchPoints > 1);
+const isIosDevice = /iP(ad|hone|od)/.test(window?.navigator?.platform) || (window?.navigator?.platform === 'MacIntel' && window.navigator.maxTouchPoints > 1);
 let documentListenerAdded = false;
 let previousBodyOverflowSetting;
 
 export const disableBodyScroll = (targetElement) => {
     if (!targetElement) return;
-    if (IS_IOS) {
+    if (isIosDevice) {
         document.body.style.position = 'fixed';
         targetElement.ontouchmove = (event) => {
             if (event.targetTouches.length === 1) {
@@ -28,7 +28,7 @@ export const disableBodyScroll = (targetElement) => {
 
 export const enableBodyScroll = (targetElement) => {
     if (!targetElement) return;
-    if (IS_IOS) {
+    if (isIosDevice) {
         targetElement.ontouchstart = null;
         targetElement.ontouchmove = null;
         document.body.style.position = '';


### PR DESCRIPTION
This PR addresses the comment made in the CC PR: https://github.com/adobecom/cc/pull/335 .
It renames isIosDevice constant to IS_IOS and simplifies the ternary statement using optional chaining.

Resolves: [MWPW-147716](https://jira.corp.adobe.com/browse/MWPW-147716)

Test URLs:
Before: https://main--cc--adobecom.hlx.live/products/catalog?martech=off&georouting=off&mep=off
After: https://mwpw-147716-merch-sidenav-scroll-lock--cc--adobecom.hlx.live/products/catalog?martech=off&georouting=off&mep=off
