### PR TITLE
MWPW-153246 Promo/sub texts update to Mini-compare card causing CTA misalignment

### DIFF
--- a/web-components/src/global.css.js
+++ b/web-components/src/global.css.js
@@ -422,11 +422,12 @@ merch-card [slot="promo-text"] {
 
 merch-card[variant="mini-compare-chart"] [slot="body-xxs"] {
     font-size: var(--consonant-merch-card-body-xs-font-size);
-    padding: var(--consonant-merch-spacing-xs) var(--consonant-merch-spacing-s) 0;    
+    padding: var(--consonant-merch-spacing-xs) var(--consonant-merch-spacing-s);    
 }
 
 merch-card[variant="mini-compare-chart"] [slot="promo-text"] {
     font-size: var(--consonant-merch-card-body-m-font-size);
+    line-height: var(--consonant-merch-card-body-m-font-size);
     padding: var(--consonant-merch-spacing-xs) var(--consonant-merch-spacing-s) 0;
 }
 
@@ -488,7 +489,7 @@ merch-card[variant="mini-compare-chart"] .footer-row-cell-description a {
     }
 
     merch-card[variant="mini-compare-chart"] [slot="offers"] {
-        padding: 0 var(--consonant-merch-spacing-xs);
+        padding: var(--consonant-merch-spacing-xxs) var(--consonant-merch-spacing-xs);
     }
 
     merch-card[variant="mini-compare-chart"] [slot='heading-m-price'] {
@@ -510,7 +511,7 @@ merch-card[variant="mini-compare-chart"] .footer-row-cell-description a {
 
     merch-card[variant="mini-compare-chart"] [slot="body-xxs"] {
         font-size: var(--consonant-merch-card-body-xs-font-size);
-        padding: 0 var(--consonant-merch-spacing-xs);
+        padding: var(--consonant-merch-spacing-xs);
     }
 
     merch-card[variant="mini-compare-chart"] [slot="promo-text"] {
@@ -532,6 +533,14 @@ merch-card[variant="mini-compare-chart"] .footer-row-cell-description a {
     merch-card[variant="mini-compare-chart"] .footer-row-cell-description {
         font-size: var(--consonant-merch-card-body-xs-font-size);
         line-height: var(--consonant-merch-card-body-xs-line-height);
+    }
+    
+    merch-card[variant="mini-compare-chart"] div[slot="footer"] > p.action-area {
+        display: block;
+    }
+    
+    merch-card[variant="mini-compare-chart"] div[slot="footer"] a.con-button ~ a.con-button {
+        margin-top: var(--consonant-merch-spacing-xs);
     }
 }
 

--- a/web-components/src/merch-card.css.js
+++ b/web-components/src/merch-card.css.js
@@ -301,13 +301,14 @@ export const styles = css`
     }
 
     :host([variant='mini-compare-chart']) footer {
-        min-height: var(--consonant-merch-card-mini-compare-footer-height);
         padding: var(--consonant-merch-spacing-xs);
+        flex-grow: 1;
     }
 
     /* mini-compare card  */
     :host([variant='mini-compare-chart']) .top-section {
         padding-top: var(--consonant-merch-spacing-s);
+        padding-bottom: var(--consonant-merch-spacing-xxs);
         padding-inline-start: var(--consonant-merch-spacing-s);
         height: var(--consonant-merch-card-mini-compare-top-section-height);
     }
@@ -328,6 +329,10 @@ export const styles = css`
             font-size: var(--consonant-merch-card-detail-font-size);
             padding: 6px 8px;
             top: 10px;
+            max-width: 65px;
+        }
+        :host([variant='mini-compare-chart']) .top-section.badge {
+            padding-inline-start: var(--consonant-merch-spacing-xs);
         }
     }
     @media screen and ${unsafeCSS(DESKTOP_UP)} {


### PR DESCRIPTION
Fixes for many different problems reported for mobile screen :
- Badge and icon overlapping. Icon is now left aligned and badge width limited to 65px, text can wrap
- More space added around subtext and promo text
- CTAs aligned horizontally 

<img width="851" alt="Screenshot 2024-07-05 at 17 09 57" src="https://github.com/adobecom/mas/assets/37440641/e135f86f-d1bf-449c-9c7e-3793e09ca38b">


Fix #[MWPW-153246](https://jira.corp.adobe.com/browse/MWPW-153246)

Test URLs:
- Before: https://main--mas--adobecom.hlx.live/
- After: https://mwpw153246--mas--bozojovicic.hlx.live/
