### PR TITLE
MWPW-153245 [merch-card] dispatch sort & search event for analytics

### DIFF
--- a/web-components/src/constants.js
+++ b/web-components/src/constants.js
@@ -37,3 +37,6 @@ export const EVENT_MERCH_STORAGE_CHANGE = 'merch-storage:change';
 
 export const EVENT_MERCH_QUANTITY_SELECTOR_CHANGE =
     'merch-quantity-selector:change';
+
+/** Event to dispatch when any action is done that requires analytics report from the parent */
+export const EVENT_MERCH_CHANGE = 'merch-change';

--- a/web-components/src/merch-card-collection.js
+++ b/web-components/src/merch-card-collection.js
@@ -7,6 +7,7 @@ import { updateLiterals } from './literals.js';
 import { TABLET_DOWN } from './media.js';
 import { styles } from './merch-card-collection.css.js';
 import { getSlotText } from './utils.js';
+import { EVENT_MERCH_CHANGE } from './constants';
 
 const MERCH_CARD_COLLECTION = 'merch-card-collection';
 
@@ -307,10 +308,13 @@ export class MerchCardCollection extends LitElement {
         }
 
         this.dispatchEvent(
-            new CustomEvent('sort-changed', {
+            new CustomEvent(EVENT_MERCH_CHANGE, {
                 bubbles: true,
                 composed: true,
-                detail: { value: event.target.value },
+                detail: {
+                    type: 'sort',
+                    value: event.target.value
+                },
             })
         );
     }
@@ -319,6 +323,15 @@ export class MerchCardCollection extends LitElement {
         const page = this.page + 1;
         pushState({ page });
         this.page = page;
+        this.dispatchEvent(
+            new CustomEvent(EVENT_MERCH_CHANGE, {
+                bubbles: true,
+                composed: true,
+                detail: {
+                    type: 'show-more',
+                },
+            })
+        );
         await this.updateComplete;
     }
 

--- a/web-components/src/merch-card-collection.js
+++ b/web-components/src/merch-card-collection.js
@@ -305,6 +305,14 @@ export class MerchCardCollection extends LitElement {
         } else {
             pushState({ sort: event.target.value });
         }
+
+        this.dispatchEvent(
+            new CustomEvent('sort-changed', {
+                bubbles: true,
+                composed: true,
+                detail: { value: event.target.value },
+            })
+        );
     }
 
     async showMore() {

--- a/web-components/src/merch-card.js
+++ b/web-components/src/merch-card.js
@@ -14,6 +14,7 @@ import {
     EVENT_MERCH_OFFER_SELECT_READY,
     EVENT_MERCH_QUANTITY_SELECTOR_CHANGE,
     EVENT_MERCH_STORAGE_CHANGE,
+    EVENT_MERCH_CHANGE,
 } from './constants.js';
 import { getTextNodes } from './utils.js';
 
@@ -250,6 +251,17 @@ export class MerchCard extends LitElement {
             'slot[name="action-menu-content"]',
         );
         if (!actionMenuContentSlot) return;
+        if (!retract) {
+            this.dispatchEvent(
+                new CustomEvent(EVENT_MERCH_CHANGE, {
+                    bubbles: true,
+                    composed: true,
+                    detail: {
+                        type: 'action-menu'
+                    },
+                })
+            );
+        }
         actionMenuContentSlot.classList.toggle('hidden', retract);
     }
 

--- a/web-components/src/merch-search.js
+++ b/web-components/src/merch-search.js
@@ -17,16 +17,31 @@ export class MerchSearch extends LitElement {
 
     constructor() {
         super();
-        this.handleInput = () =>
+
+        this.handleInput = () => {
             pushStateFromComponent(this, this.search.value);
+        };
+        this.handleInputAndAnalytics = () => {
+            pushStateFromComponent(this, this.search.value);
+            if (this.search.value) {
+                this.dispatchEvent(
+                    new CustomEvent('search-changed', {
+                        bubbles: true,
+                        composed: true,
+                        detail: { value: this.search.value },
+                    })
+                );
+            }
+        };
         this.handleInputDebounced = debounce(this.handleInput.bind(this));
+        this.handleChangeDebounced = debounce(this.handleInputAndAnalytics.bind(this));
     }
 
     connectedCallback() {
         super.connectedCallback();
         if (!this.search) return;
         this.search.addEventListener('input', this.handleInputDebounced);
-        this.search.addEventListener('change', this.handleInputDebounced);
+        this.search.addEventListener('change', this.handleChangeDebounced);
         this.search.addEventListener('submit', this.handleInputSubmit);
         this.updateComplete.then(() => {
             this.setStateFromURL();

--- a/web-components/src/merch-search.js
+++ b/web-components/src/merch-search.js
@@ -1,5 +1,6 @@
 import { html, LitElement, css } from 'lit';
 import { debounce } from './utils';
+import { EVENT_MERCH_CHANGE } from './constants';
 import {
     deeplink,
     pushStateFromComponent,
@@ -25,10 +26,13 @@ export class MerchSearch extends LitElement {
             pushStateFromComponent(this, this.search.value);
             if (this.search.value) {
                 this.dispatchEvent(
-                    new CustomEvent('search-changed', {
+                    new CustomEvent(EVENT_MERCH_CHANGE, {
                         bubbles: true,
                         composed: true,
-                        detail: { value: this.search.value },
+                        detail: {
+                            type: 'search',
+                            value: this.search.value
+                        },
                     })
                 );
             }
@@ -52,7 +56,7 @@ export class MerchSearch extends LitElement {
     disconnectedCallback() {
         super.disconnectedCallback();
         this.search.removeEventListener('input', this.handleInputDebounced);
-        this.search.removeEventListener('change', this.handleInputDebounced);
+        this.search.removeEventListener('change', this.handleChangeDebounced);
         this.search.removeEventListener('submit', this.handleInputSubmit);
         this.stopDeeplink?.();
     }


### PR DESCRIPTION
When "click" event is fired from shadow dom and caught on root node, the target element is "merch card collection" so we can't really know where the click happened. So I had to fire custom events for sort and search change. It will be handled in CC code here [catalog.js](https://github.com/bozojovicic/cc/blob/mwpw153245/creativecloud/blocks/catalog/catalog.js#L50-L61)
Also have in mind that new version of `mas/libs/merch-sidenav.js` needs to be copied to  `cc/creativecloud/deps/merch-sidenav.js`
(I created the branch with the working code but can't create PR for CC before this PR is merged.)
In the event handler I had to go from the target node up the dom structure to collect values of all daa-lh attributes to manually construct the event name for analytics since this analytics request is also fired manually with 
`window._satellite?.track('event', { ... })`

Event name for sort : `alphabetical--sort|s2|b1|catalog|nopzn|catalog-devicet`
Event name for search, if user searched for "lightroom" : `lightroom--search|s2|b1|catalog|nopzn|catalog-devicet|b1|sidenav|b1|search`
Event name for Show More : `show-more|s2|b1|catalog|nopzn|catalog-devicet|all--cat`
Event name for Card Action Menu : `action-menu|s2|b1|catalog|nopzn|catalog-devicet|all--cat`
Event name for Card Icon click : `merch-icon-click|s2|b1|catalog|nopzn|catalog-devicet|photo--cat`

Test page [here](https://mwpw153245--cc--bozojovicic.hlx.live/products/catalog?milolibs=mwpw153245--milo--bozojovicic#category=all)

Fix #[MWPW-153245](https://jira.corp.adobe.com/browse/MWPW-153245)

Test URLs:
- Before: https://main--mas--adobecom.hlx.live/
- After: https://mwpw153245--mas--bozojovicic.hlx.live/
