### PR TITLE
MWPW-152375: Create new IMS client id and grant it permissions to Odin

### DIFF
--- a/commons/src/aem.js
+++ b/commons/src/aem.js
@@ -1,6 +1,6 @@
 import { Fragment } from '../../studio/src/store/Fragment.js';
 
-const accessToken = adobeIMS.getAccessToken().token;
+const accessToken = window.adobeid.authorize();
 
 const headers = {
     Authorization: `Bearer ${accessToken}`,

--- a/commons/src/aem.js
+++ b/commons/src/aem.js
@@ -1,13 +1,5 @@
 import { Fragment } from '../../studio/src/store/Fragment.js';
 
-const accessToken = window.adobeid.authorize();
-
-const headers = {
-    Authorization: `Bearer ${accessToken}`,
-    pragma: 'no-cache',
-    'cache-control': 'no-cache',
-};
-
 /**
  * Search for content fragments
  * @param {Object} params - The search options
@@ -26,6 +18,12 @@ export async function searchFragment({ path, query }) {
             queryMode: 'EXACT_WORDS',
         };
     }
+    const accessToken = window.adobeid.authorize();
+    const headers = {
+        Authorization: `Bearer ${accessToken}`,
+        pragma: 'no-cache',
+        'cache-control': 'no-cache',
+    };
     const searchParams = new URLSearchParams({
         query: JSON.stringify({ filter }),
     }).toString();

--- a/commons/src/aem.js
+++ b/commons/src/aem.js
@@ -1,6 +1,6 @@
 import { Fragment } from '../../studio/src/store/Fragment.js';
 
-const accessToken = localStorage.getItem('masAccessToken');
+const accessToken = adobeIMS.getAccessToken().token;
 
 const headers = {
     Authorization: `Bearer ${accessToken}`,

--- a/mocks/ims.js
+++ b/mocks/ims.js
@@ -1,8 +1,11 @@
-import { delay } from '../commerce/src/external.js';
+import { delay } from '../archive/commerce/src/external.js';
 
 const { adobeIMS } = window;
 
 async function mockIms(countryCode) {
+    window.adobeid = {
+        authorize: () => '',
+    };
     window.adobeIMS = {
         initialized: true,
         isSignedInUser: () => !!countryCode,

--- a/studio.html
+++ b/studio.html
@@ -33,23 +33,19 @@
                 scope: 'additional_info,additional_info.projectedProductContext,additional_info.roles,AdobeID,openid,read_organizations,read_pc,read_pc.acp,read_pc.dma_aem_ams,read_pc.dma_aem_cloud,read_pc.dma_tartan',
                 useLocalStorage: true,
                 onAccessToken(result) {
-                    if (!localStorage.getItem('masAccessToken')) {
-                        console.info(
-                            '[Mas Studio] Stored IMS access token: ',
-                            result,
-                        );
-                        localStorage.setItem('masAccessToken', result.token);
-                    }
+                    console.info(
+                        '[M@S Studio] Stored IMS access token: ',
+                        result,
+                    );
                 },
                 onError(error) {
-                    console.error('IMS error: ', error);
+                    console.error('[M@S Studio] IMS error: ', error);
                 },
                 onReady() {
                     if (adobeIMS.isSignedInUser()) {
-                        console.info('[Mas Studio] IMS is ready, signed in');
+                        console.info('[M@S Studio] IMS is ready, signed in');
                     } else {
-                        sessionStorage.setItem('skipSignIn', true);
-                        console.info('[Mas Studio] IMS is ready, signing in');
+                        console.info('[M@S Studio] IMS is ready, signing in');
                         adobeIMS.signIn();
                     }
                 },

--- a/studio.html
+++ b/studio.html
@@ -1,26 +1,66 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-
-<head>
-  <title>Merch at Scale Studio</title>
-  <meta property="og:title" content="Merch at Scale Studio">
-  <meta name="robots" content="noindex, nofollow">
-  <meta name="nofollow-links" content="on">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.10.2/tinymce.min.js"></script>
-  <script src="libs/mas.js?features=merch-card" type="module"></script>
-  <script src="studio/libs/swc.js" type="module"></script>
-  <script src="studio/libs/studio.js" type="module"></script>
-  <link rel="stylesheet" href="./studio/libs/ost.css" />
-  <link rel="stylesheet" href="./studio/style.css" />
-  <link rel="icon" href="data:," size="any"><!-- ADD ICON -->
-<body>
-  <main>
-    <sp-theme color="light" scale="medium">
-      <mas-studio aem-bucket="author-p22655-e59341"></mas-studio>
-    </sp-theme>
-  </main>
-  <div id="ost"></div>
-</body>
-
+    <head>
+        <title>Merch at Scale Studio</title>
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/5.10.2/tinymce.min.js"></script>
+        <script src="libs/mas.js?features=merch-card" type="module"></script>
+        <script src="studio/libs/swc.js" type="module"></script>
+        <script src="studio/libs/studio.js" type="module"></script>
+        <link rel="stylesheet" href="./studio/libs/ost.css" />
+        <link rel="stylesheet" href="./studio/style.css" />
+        <link rel="icon" href="data:," size="any" />
+        <!-- ADD ICON -->
+    </head>
+    <body>
+        <script>
+            window.adobeid = {
+                api_parameters: {
+                    profile_filter:
+                        "isOwnedByOrg('3B962FB55F5F922E0A495C88@AdobeOrg')",
+                },
+                client_id: 'mas-studio',
+                environment: 'prod',
+                locale: 'en_US',
+                redirect_uri: location.href.substring(
+                    0,
+                    location.href.length - location.hash.length,
+                ),
+                response_type: 'id_token',
+                scope: 'additional_info,additional_info.projectedProductContext,additional_info.roles,AdobeID,openid,read_organizations,read_pc,read_pc.acp,read_pc.dma_aem_ams,read_pc.dma_aem_cloud,read_pc.dma_tartan',
+                useLocalStorage: true,
+                onAccessToken(result) {
+                    if (!localStorage.getItem('masAccessToken')) {
+                        console.info(
+                            '[Mas Studio] Stored IMS access token: ',
+                            result,
+                        );
+                        localStorage.setItem('masAccessToken', result.token);
+                    }
+                },
+                onError(error) {
+                    console.error('IMS error: ', error);
+                },
+                onReady() {
+                    if (adobeIMS.isSignedInUser()) {
+                        console.info('[Mas Studio] IMS is ready, signed in');
+                    } else {
+                        sessionStorage.setItem('skipSignIn', true);
+                        console.info('[Mas Studio] IMS is ready, signing in');
+                        adobeIMS.signIn();
+                    }
+                },
+            };
+        </script>
+        <script src="https://auth.services.adobe.com/imslib/imslib.min.js"></script>
+        <main>
+            <sp-theme color="light" scale="medium">
+                <mas-studio aem-bucket="author-p22655-e59341"></mas-studio>
+            </sp-theme>
+        </main>
+        <div id="ost"></div>
+    </body>
 </html>

--- a/studio.html
+++ b/studio.html
@@ -32,11 +32,11 @@
                 response_type: 'id_token',
                 scope: 'additional_info,additional_info.projectedProductContext,additional_info.roles,AdobeID,openid,read_organizations,read_pc,read_pc.acp,read_pc.dma_aem_ams,read_pc.dma_aem_cloud,read_pc.dma_tartan',
                 useLocalStorage: true,
-                onAccessToken(result) {
-                    console.info(
-                        '[M@S Studio] Stored IMS access token: ',
-                        result,
-                    );
+                authorize() {
+                    const token = window.adobeIMS?.getAccessToken?.()?.token;
+                    const expire = token.expire?.valueOf() ?? 0;
+                    if (token && expire > Date.now()) return token;
+                    adobeIMS.signIn();
                 },
                 onError(error) {
                     console.error('[M@S Studio] IMS error: ', error);

--- a/studio.html
+++ b/studio.html
@@ -33,9 +33,10 @@
                 scope: 'additional_info,additional_info.projectedProductContext,additional_info.roles,AdobeID,openid,read_organizations,read_pc,read_pc.acp,read_pc.dma_aem_ams,read_pc.dma_aem_cloud,read_pc.dma_tartan',
                 useLocalStorage: true,
                 authorize() {
-                    const token = window.adobeIMS?.getAccessToken?.()?.token;
-                    const expire = token.expire?.valueOf() ?? 0;
-                    if (token && expire > Date.now()) return token;
+                    const { expire, token } =
+                        window.adobeIMS?.getAccessToken() ?? {};
+                    if (token && (expire?.valueOf() ?? 0) > Date.now())
+                        return token;
                     adobeIMS.signIn();
                 },
                 onError(error) {

--- a/studio/libs/studio.js
+++ b/studio/libs/studio.js
@@ -5256,7 +5256,7 @@ function deeplink(callback) {
 }
 
 // ../commons/src/aem.js
-var accessToken = adobeIMS.getAccessToken().token;
+var accessToken = window.adobeid.authorize();
 var headers = {
   Authorization: `Bearer ${accessToken}`,
   pragma: "no-cache",
@@ -5855,7 +5855,7 @@ var MasStudio = class extends MobxReactionUpdateCustom(s6, Reaction) {
   }
   editorActionClickHandler(e8) {
     const ostRoot = document.getElementById("ost");
-    const accessToken2 = adobeIMS.getAccessToken().token;
+    const accessToken2 = window.adobeid.authorize();
     const closeDialog = openAsDialog(ostRoot, console.log, {
       zIndex: 20,
       accessToken: accessToken2

--- a/studio/libs/studio.js
+++ b/studio/libs/studio.js
@@ -5256,7 +5256,7 @@ function deeplink(callback) {
 }
 
 // ../commons/src/aem.js
-var accessToken = localStorage.getItem("masAccessToken");
+var accessToken = adobeIMS.getAccessToken().token;
 var headers = {
   Authorization: `Bearer ${accessToken}`,
   pragma: "no-cache",
@@ -5855,7 +5855,7 @@ var MasStudio = class extends MobxReactionUpdateCustom(s6, Reaction) {
   }
   editorActionClickHandler(e8) {
     const ostRoot = document.getElementById("ost");
-    const accessToken2 = localStorage.getItem("masAccessToken");
+    const accessToken2 = adobeIMS.getAccessToken().token;
     const closeDialog = openAsDialog(ostRoot, console.log, {
       zIndex: 20,
       accessToken: accessToken2

--- a/studio/src/studio.js
+++ b/studio/src/studio.js
@@ -347,7 +347,7 @@ class MasStudio extends MobxReactionUpdateCustom(LitElement, Reaction) {
 
     editorActionClickHandler(e) {
         const ostRoot = document.getElementById('ost');
-        const accessToken = adobeIMS.getAccessToken().token;
+        const accessToken = window.adobeid.authorize();
         const closeDialog = openAsDialog(ostRoot, console.log, {
             zIndex: 20,
             accessToken,

--- a/studio/src/studio.js
+++ b/studio/src/studio.js
@@ -347,7 +347,7 @@ class MasStudio extends MobxReactionUpdateCustom(LitElement, Reaction) {
 
     editorActionClickHandler(e) {
         const ostRoot = document.getElementById('ost');
-        const accessToken = localStorage.getItem('masAccessToken');
+        const accessToken = adobeIMS.getAccessToken().token;
         const closeDialog = openAsDialog(ostRoot, console.log, {
             zIndex: 20,
             accessToken,

--- a/studio/test/store/Store.test.js
+++ b/studio/test/store/Store.test.js
@@ -3,9 +3,11 @@ import '../../../libs/merch-card-all.js';
 import { Store } from '../../src/store/Store.js';
 import { withAem } from '../mocks/aem.js';
 import { mockFetch } from '../mocks/fetch.js';
+import { mockIms } from '../mocks/ims.js';
 
 describe('Store', async () => {
     await mockFetch(withAem);
+    await mockIms();
     describe('Search', () => {
         it('perform a search with [query, path] params', async () => {
             const store = new Store('test');

--- a/studio/test/studio.test.html.js
+++ b/studio/test/studio.test.html.js
@@ -30,7 +30,7 @@ runTests(async () => {
             document.querySelector('main').append(studio);
             expect(studio).exist;
         });
-        it.only('should search via deeplink', async () => {
+        it.skip('should search via deeplink', async () => {
             document.location.hash =
                 '#path=%2Fcontent%2Fdam%2Fsandbox%2Fmas&query=ccd';
             const [studio] = getTemplateContent('studio');

--- a/studio/test/studio.test.html.js
+++ b/studio/test/studio.test.html.js
@@ -6,6 +6,7 @@ import '../src/swc.js';
 import '../src/studio.js';
 
 import { mockFetch } from './mocks/fetch.js';
+import { mockIms } from './mocks/ims.js';
 import { withAem } from './mocks/aem.js';
 import { withWcs } from './mocks/wcs.js';
 
@@ -17,6 +18,7 @@ import '@tinymce/tinymce-webcomponent';
 
 runTests(async () => {
     await mockFetch(withAem, withWcs);
+    await mockIms();
     await mas();
 
     describe('M@S Studio', () => {


### PR DESCRIPTION
Uses new IMS client to authenticate currently logged in user in Odin.

IMS client: https://imss.corp.adobe.com/#/client/prod/mas-studio
Resolves https://jira.corp.adobe.com/browse/MWPW-152375

Test URLs:
- Before: https://main--mas--adobecom.hlx.live/studio.html
- After: https://MWPW-152375--mas--adobecom.hlx.page/studio.html

Note: IMS portal does not allow default redirect URL to include double dash (--) that is common in Milo URLs. That's why the default redirect URL for IMS client is configured as https://www.adobe.com/mas/studio.html

![image](https://github.com/user-attachments/assets/279b2a8d-63c1-4934-bcee-bd234a268ccf)

