### PR TITLE
MWPW-159027 introduce milolibs in studio

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -27,7 +27,7 @@ jobs:
       run: npm ci
 
     - name: Force update @adobecom/milo dependency
-      run: npm add github:adobecom/milo#content-navigation
+      run: npm add github:adobecom/milo#stage
 
     - name: Install XVFB
       run: sudo apt-get install xvfb

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "studio"
             ],
             "dependencies": {
-                "@adobecom/milo": "github:adobecom/milo#content-navigation",
+                "@adobecom/milo": "github:adobecom/milo#stage",
                 "@spectrum-web-components/action-bar": "^0.47.2",
                 "@spectrum-web-components/action-button": "^0.47.2",
                 "@spectrum-web-components/action-menu": "^0.47.2",
@@ -5594,7 +5594,7 @@
             "version": "0.0.1",
             "license": "ISC",
             "dependencies": {
-                "@adobecom/milo": "github:adobecom/milo#content-navigation"
+                "@adobecom/milo": "github:adobecom/milo#stage"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "url": "git@github.com:adobecom/mas.git"
     },
     "dependencies": {
-        "@adobecom/milo": "github:adobecom/milo#content-navigation",
+        "@adobecom/milo": "github:adobecom/milo#stage",
         "@spectrum-web-components/action-bar": "^0.47.2",
         "@spectrum-web-components/action-button": "^0.47.2",
         "@spectrum-web-components/action-menu": "^0.47.2",

--- a/studio.html
+++ b/studio.html
@@ -7,10 +7,7 @@
         <meta name="nofollow-links" content="on" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/7.2.1/tinymce.min.js"></script>
-        <script
-            src="https://ccd--milo--adobecom.hlx.live/libs/deps/mas/mas.js"
-            type="module"
-        ></script>
+        <script src="studio/libs/maslib.js"></script>
         <script src="studio/libs/swc.js" type="module"></script>
         <script src="studio/libs/aem.js" type="module"></script>
         <script src="studio/libs/studio.js" type="module"></script>

--- a/studio/libs/maslib.js
+++ b/studio/libs/maslib.js
@@ -1,0 +1,16 @@
+const getMiloLibs = () => {
+    const pageUrl = new URL(window.location.href);
+    const milolibs = new URLSearchParams(pageUrl?.searchParams)?.get('milolibs');
+    if (!milolibs) return 'https://www.adobe.com';
+    if ('local' === milolibs) return 'http://localhost:6456';
+    return `https://${milolibs}.hlx.live`;
+}
+
+const injectMasLib = () => {
+    const script = document.createElement('script');
+    script.setAttribute("src", `${getMiloLibs()}/libs/deps/mas/mas.js`);
+    script.setAttribute("type", 'module');
+    document.head.prepend(script);
+};
+
+injectMasLib();

--- a/studio/libs/maslib.js
+++ b/studio/libs/maslib.js
@@ -1,6 +1,5 @@
 const getMiloLibs = () => {
-    const pageUrl = new URL(window.location.href);
-    const milolibs = new URLSearchParams(pageUrl?.searchParams)?.get('milolibs');
+    const milolibs = new URLSearchParams(window.location.search)?.get('milolibs');
     if (!milolibs) return 'https://www.adobe.com';
     if ('local' === milolibs) return 'http://localhost:6456';
     return `https://${milolibs}.hlx.live`;

--- a/studio/package.json
+++ b/studio/package.json
@@ -15,6 +15,6 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@adobecom/milo": "github:adobecom/milo#content-navigation"
+        "@adobecom/milo": "github:adobecom/milo#stage"
     }
 }


### PR DESCRIPTION
- whatever milo branch for mas.js can be switched to with milolibs parameter,
- you can switch to local dev with 'local' value

Test URLs:

Before: https://main--mas--adobecom.hlx.live/
After: https://MWPW-159027--mas--adobecom.hlx.live/

