### PR TITLE
MWPW-158050: add local setup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--mas--adobecom.hlx.live/
-- After: https://<branch>--mas--adobecom.hlx.live/
+- Before: https://main--mas--adobecom.hlx.live/studio.html
+- After: https://<branch>--mas--adobecom.hlx.live/studio.html

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
 
-Fix #<gh-issue-id>
+Resolve <JIRA>
 
 Test URLs:
 - Before: https://main--mas--adobecom.hlx.live/studio.html

--- a/README.md
+++ b/README.md
@@ -20,21 +20,12 @@ npm run lint
 ## Local development
 ```
 npm run build
-aem up
+npm run studio
 ```
 
 Refer to the corresponding README.md under any of the packages:
-* commerce - contains generic commerce-related logic, 'price' and 'checkout-link' web components
-* web-components - merch-card, merch-offer-selector and other web components
 * studio - M@S Studio for creating, updating and publishing merch fragments
-
-# Pre push hook
-Before each push 'npm run build' is triggered.
-1. It will build the artifacts in the /libs folder
-2. If any of the artifacts have an update the hook will stage the changes and commit
-3. If there are unstaged/uncommitted changes the hook will prevent the push
-
-There is no need to run 'npm run build' manually, but if you run it and commit - no issue (then hook won't do an additional commit).
+* ost-audit - crawls EDS pages HTML for OST links and generates a CSV report
 
 
 #### Troubleshooting

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "scripts": {
         "lint": "eslint --fix",
         "test": "npm run test:ci --workspaces",
-        "build": "npm run build --workspaces"
+        "build": "npm run build --workspaces",
+        "studio": "cd studio && npm run proxy & aem up"
     },
     "repository": {
         "type": "git",

--- a/studio.html
+++ b/studio.html
@@ -6,7 +6,7 @@
         <meta name="robots" content="noindex, nofollow" />
         <meta name="nofollow-links" content="on" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="aem-base-url" content="https://author-p22655-e155390.adobeaemcloud.com/" />
+        <meta name="aem-base-url"/>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/7.2.1/tinymce.min.js"></script>
         <script src="studio/libs/maslib.js"></script>
         <script src="studio/libs/swc.js" type="module"></script>
@@ -60,11 +60,14 @@
     </head>
     <body>
         <main>
-            <sp-theme color="light" scale="medium">
-                <mas-studio
-                    aem-bucket="author-p22655-e155390"
-                ></mas-studio>
-            </sp-theme>
+            <sp-theme color="light" scale="medium"></sp-theme>
         </main>
+        <script>
+            let baseUrl = window.location.href.includes('localhost') ? 'http://localhost:8080' : 'https://qa-odin.adobe.com';
+            document.querySelector('meta[name="aem-base-url"]')?.setAttribute('content', baseUrl);
+            const studio = document.createElement('mas-studio');
+            studio.setAttribute('base-url', baseUrl)
+            document.querySelector('sp-theme').appendChild(studio);
+        </script>
     </body>
 </html>


### PR DESCRIPTION
Allows to run studio locally with 1 command from the root: npm run studio
This will start proxy to odin and aem up.

Test URLs:
- Before: https://main--mas--adobecom.hlx.live/studio.html?milolibs=stage--milo--adobecom#query=ccd
- After: https://MWPW-158050--mas--adobecom.hlx.live/studio.html?milolibs=stage--milo--adobecom#query=ccd
