### PR TITLE
MWPW-161845: add link analytics id's

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ aem up --port 6456
 ```
 and access studio at http://localhost:3000/studio.html?milolibs=local
 
+to test gallery:
+1. shut down npm run studio if you were running it.
+2.
+```
+npm run gallery
+```
+
 Refer to the corresponding README.md under any of the packages:
 * studio - M@S Studio for creating, updating and publishing merch fragments
 * ost-audit - crawls EDS pages HTML for OST links and generates a CSV report

--- a/studio/src/constants.js
+++ b/studio/src/constants.js
@@ -1,0 +1,22 @@
+export const CHECKOUT_CTA_TEXTS = {
+    'buy-now': 'Buy now',
+    'free-trial': 'Free trial',
+    'start-free-trial': 'Start free trial',
+    'save-now': 'Save now',
+    'get-started': 'Get started',
+    'choose-a-plan': 'Choose a plan',
+    'learn-more': 'Learn more',
+    'change-plan-team-plans': 'Change Plan Team Plans',
+    upgrade: 'Upgrade',
+    'change-plan-team-payment': 'Change Plan Team Payment',
+    'take-the-quiz': 'Take the quiz',
+    'see-more': 'See more',
+    'upgrade-now': 'Upgrade now',
+    'get-offer': 'Get offer',
+};
+
+export const ANALYTICS_LINK_IDS = [
+    'learn-more',
+    'see-terms',
+    'what-is-included',
+];

--- a/studio/src/rte/ost.js
+++ b/studio/src/rte/ost.js
@@ -1,23 +1,8 @@
 import { html } from 'lit';
+import { CHECKOUT_CTA_TEXTS } from '../constants.js';
 
 let ostRoot;
 let closeFunction;
-
-const ctaTexts = {
-    'buy-now': 'Buy now',
-    'free-trial': 'Free trial',
-    'start-free-trial': 'Start free trial',
-    'save-now': 'Save now',
-    'get-started': 'Get started',
-    'choose-a-plan': 'Choose a plan',
-    'learn-more': 'Learn more',
-    'change-plan-team-plans': 'Change Plan Team Plans',
-    upgrade: 'Upgrade',
-    'change-plan-team-payment': 'Change Plan Team Payment',
-    'take-the-quiz': 'Take the quiz',
-    'see-more': 'See more',
-    'upgrade-now': 'Upgrade now',
-};
 
 export const ostDefaults = {
     aosApiKey: 'wcms-commerce-ims-user-prod',
@@ -37,7 +22,10 @@ export const ostDefaults = {
     },
     wcsApiKey: 'wcms-commerce-ims-ro-user-cc',
     ctaTextOption: {
-        ctaTexts: Object.entries(ctaTexts).map(([id, name]) => ({ id, name })),
+        ctaTexts: Object.entries(CHECKOUT_CTA_TEXTS).map(([id, name]) => ({
+            id,
+            name,
+        })),
         getDefaultText() {
             return this.ctaTexts[0].id;
         },
@@ -140,9 +128,10 @@ export function onSelect(offerSelectorId, type, offer, options, promoOverride) {
         attributes.is = is;
     }
 
-    const ctaText = ctaTexts[options.ctaText]; // no placeholder key support.
+    const ctaText = CHECKOUT_CTA_TEXTS[options.ctaText]; // no placeholder key support.
     if (ctaText) {
         attributes['text'] = ctaText;
+        attributes['data-analytics-id'] = options.ctaText;
     }
 
     if (promoOverride) {

--- a/studio/src/rte/rte-field.js
+++ b/studio/src/rte/rte-field.js
@@ -234,6 +234,7 @@ class RteField extends LitElement {
                     'data-wcs-osi': { default: null },
                     title: { default: null },
                     target: { default: null },
+                    'data-analytics-id': { default: null },
                 },
                 parseDOM: [{ tag: 'a', getAttrs: this.#collectDataAttributes }],
                 toDOM: this.#createLinkElement.bind(this),
@@ -463,6 +464,7 @@ class RteField extends LitElement {
                 text: selection.node.textContent || '',
                 target: selection.node.attrs.target || '_self',
                 variant: selection.node.attrs.class || '',
+                analyticsId: selection.node.attrs['data-analytics-id'] || '',
                 checkoutParameters,
             };
         }
@@ -474,6 +476,7 @@ class RteField extends LitElement {
                 text: state.doc.textBetween(selection.from, selection.to),
                 target: '_self',
                 variant: this.defaultLinkStyle,
+                analyticsId: '',
                 checkoutParameters,
             };
         }
@@ -484,12 +487,14 @@ class RteField extends LitElement {
             text: '',
             target: '_self',
             variant: this.defaultLinkStyle,
+            analyticsId: '',
             checkoutParameters,
         };
     }
 
     #handleLinkSave(event) {
-        const { href, text, title, target, variant } = event.detail;
+        const { href, text, title, target, variant, analyticsId } =
+            event.detail;
 
         let { checkoutParameters } = event.detail;
         const { state, dispatch } = this.editorView;
@@ -516,6 +521,7 @@ class RteField extends LitElement {
             target: target || '_self',
             class: variant || 'primary-outline',
             'data-extra-options': checkoutParameters || null,
+            'data-analytics-id': analyticsId || null,
         };
 
         if (selection.node?.type.name === 'link') {
@@ -701,8 +707,10 @@ class RteField extends LitElement {
 
     get linkEditor() {
         if (!this.showLinkEditor) return nothing;
+        const attributes = this.editorView?.state?.selection?.node?.attrs;
         return html`<rte-link-editor
             dialog
+            .linkAttrs=${attributes}
             @save="${this.#boundHandlers.linkSave}"
         ></rte-link-editor>`;
     }

--- a/studio/src/rte/rte-link-editor.js
+++ b/studio/src/rte/rte-link-editor.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { CHECKOUT_CTA_TEXTS, ANALYTICS_LINK_IDS } from '../constants.js';
 
 export class RteLinkEditor extends LitElement {
     static properties = {
@@ -13,6 +14,12 @@ export class RteLinkEditor extends LitElement {
         checkoutParameters: {
             type: String,
             attribute: 'checkout-parameters',
+            reflect: true,
+        },
+        linkAttrs: { type: Object },
+        analyticsId: {
+            type: String,
+            attribute: 'data-analytics-id',
             reflect: true,
         },
     };
@@ -77,6 +84,7 @@ export class RteLinkEditor extends LitElement {
         this.variant = 'accent';
         this.target = '_self';
         this.open = true;
+        this.analyticsId = '';
         this.addEventListener('change', (e) => {
             // changes in the dialog should not propagate to outside
             e.stopImmediatePropagation();
@@ -90,7 +98,7 @@ export class RteLinkEditor extends LitElement {
             >
             <sp-textfield
                 id="checkoutParameters"
-                placeholder="Exrta checkout parameters: e.g: promoid=12345&mv=1"
+                placeholder="Extra checkout parameters: e.g: promoid=12345&mv=1"
                 .value=${this.checkoutParameters}
                 @input=${(e) => (this.checkoutParameters = e.target.value)}
             ></sp-textfield>`;
@@ -116,6 +124,34 @@ export class RteLinkEditor extends LitElement {
 
     get linkHrefElement() {
         return this.shadowRoot.querySelector('#linkHref');
+    }
+
+    get #checkoutLink() {
+        return this.checkoutParameters !== undefined;
+    }
+    get #analyticsIdField() {
+        const options = this.#checkoutLink
+            ? Object.keys(CHECKOUT_CTA_TEXTS)
+            : ANALYTICS_LINK_IDS;
+        return html` <sp-field-label for="analyticsId"
+                >Analytics Id</sp-field-label
+            >
+            <sp-picker
+                id="analyticsId"
+                .value=${this.analyticsId}
+                @change=${(e) => {
+                    this.analyticsId = e.target.value;
+                }}
+            >
+                <sp-menu>
+                    ${options.map(
+                        (option) =>
+                            html`<sp-menu-item value="${option}"
+                                >${option}</sp-menu-item
+                            >`,
+                    )}
+                </sp-menu>
+            </sp-picker>`;
     }
 
     get #linkVariants() {
@@ -195,8 +231,7 @@ export class RteLinkEditor extends LitElement {
     }
 
     get #editor() {
-        const type =
-            this.checkoutParameters === undefined ? 'Link' : 'Checkout Link';
+        const type = this.#checkoutLink ? 'Checkout Link' : 'Link';
         return html`<sp-dialog close=${this.#handleClose}>
             <h2 slot="heading">Insert/Edit ${type}</h2>
             ${this.#linkHrefField} ${this.#checkoutParametersField}
@@ -229,7 +264,7 @@ export class RteLinkEditor extends LitElement {
                     <sp-menu-item value="_top">Top Frame</sp-menu-item>
                 </sp-menu>
             </sp-picker>
-            ${this.#linkVariants}
+            ${this.#analyticsIdField} ${this.#linkVariants}
             <sp-button
                 id="cancelButton"
                 slot="button"
@@ -269,6 +304,7 @@ export class RteLinkEditor extends LitElement {
             title: this.title,
             target: this.target,
             variant: this.variant,
+            analyticsId: this.analyticsId,
         };
         if (this.checkoutParameters !== undefined) {
             delete data.href;

--- a/studio/src/rte/rte-link-editor.js
+++ b/studio/src/rte/rte-link-editor.js
@@ -129,10 +129,12 @@ export class RteLinkEditor extends LitElement {
     get #checkoutLink() {
         return this.checkoutParameters !== undefined;
     }
+
     get #analyticsIdField() {
         const options = this.#checkoutLink
             ? Object.keys(CHECKOUT_CTA_TEXTS)
             : ANALYTICS_LINK_IDS;
+        options.push('');
         return html` <sp-field-label for="analyticsId"
                 >Analytics Id</sp-field-label
             >
@@ -152,6 +154,10 @@ export class RteLinkEditor extends LitElement {
                     )}
                 </sp-menu>
             </sp-picker>`;
+    }
+
+    get linkAnalyticsIdElement() {
+        return this.shadowRoot.querySelector('#analyticsId');
     }
 
     get #linkVariants() {

--- a/studio/src/rte/rte-link-editor.js
+++ b/studio/src/rte/rte-link-editor.js
@@ -126,12 +126,12 @@ export class RteLinkEditor extends LitElement {
         return this.shadowRoot.querySelector('#linkHref');
     }
 
-    get #checkoutLink() {
+    get #isCheckoutLink() {
         return this.checkoutParameters !== undefined;
     }
 
     get #analyticsIdField() {
-        const options = this.#checkoutLink
+        const options = this.#isCheckoutLink
             ? Object.keys(CHECKOUT_CTA_TEXTS)
             : ANALYTICS_LINK_IDS;
         options.push('');
@@ -237,7 +237,7 @@ export class RteLinkEditor extends LitElement {
     }
 
     get #editor() {
-        const type = this.#checkoutLink ? 'Checkout Link' : 'Link';
+        const type = this.#isCheckoutLink ? 'Checkout Link' : 'Link';
         return html`<sp-dialog close=${this.#handleClose}>
             <h2 slot="heading">Insert/Edit ${type}</h2>
             ${this.#linkHrefField} ${this.#checkoutParametersField}

--- a/studio/test/rte/rte-link-editor.test.html
+++ b/studio/test/rte/rte-link-editor.test.html
@@ -42,6 +42,7 @@
                         expect(linkEditor.text).to.equal('');
                         expect(linkEditor.title).to.equal('');
                         expect(linkEditor.target).to.equal('_self');
+                        expect(linkEditor.analyticsId).to.equal('');
 
                         expect(linkEditor.linkHrefElement).to.exist;
                         expect(linkEditor.linkTextElement).to.exist;
@@ -50,6 +51,7 @@
                         expect(linkEditor.linkStyleElement).to.not.exist;
                         expect(linkEditor.checkoutParametersElement).to.not
                             .exist;
+                        expect(linkEditor.linkAnalyticsIdElement).to.exist;
                     });
 
                     it('should render given values', async function () {
@@ -83,6 +85,9 @@
                         expect(linkEditor.linkTargetElement.value).to.equal(
                             '_blank',
                         );
+                        expect(linkEditor.linkAnalyticsIdElement.value).to.equal(
+                            'see-terms',
+                        );
                     });
 
                     it('should emit save event with form data', async function () {
@@ -104,6 +109,7 @@
                             title: 'test title',
                             target: '_blank',
                             variant: 'accent',
+                            analyticsId: 'see-terms',
                         });
                     });
 
@@ -132,6 +138,7 @@
                         expect(
                             linkEditor.checkoutParametersElement.value,
                         ).to.equal('');
+                        expect(linkEditor.linkAnalyticsIdElement.value).to.equal('');
                     });
 
                     it('should support checkout and variant parameters', async function () {
@@ -151,6 +158,7 @@
                         linkEditor.checkoutParameters =
                             'promoid=test&mv=1&mv2=2';
                         linkEditor.variant = 'quiet';
+                        linkEditor.analyticsId = 'free-trial';
                         linkEditor.shadowRoot
                             .getElementById('saveButton')
                             .click();
@@ -161,6 +169,7 @@
                             title: 'test title',
                             target: '_blank',
                             variant: 'quiet',
+                            analyticsId: 'free-trial',
                         });
                     });
                 });
@@ -181,6 +190,7 @@
                 text="link text"
                 title="test title"
                 target="_blank"
+                data-analytics-id="see-terms"
             ></rte-link-editor>
         </template>
 
@@ -196,6 +206,7 @@
                 target="_blank"
                 variant="outline"
                 checkout-parameters="promoid=test&mv=other"
+                data-analytics-id="buy-now"
             ></rte-link-editor>
         </template>
     </body>


### PR DESCRIPTION
Update Link Dialog with a dropdown of Link analytics Ids.
For Checkout CTAs id's can be derived from the CTA text selected in OST.
For rest of links there is a list of valid values in dropdown.

The first 3 cards in the gallery already have the id's set

Resolve: https://jira.corp.adobe.com/browse/MWPW-161845

Test URLs:
- Before: https://main--mas--adobecom.hlx.live/studio.html
- After: https://mwpw-161845--mas--adobecom.hlx.live/studio.html#path=drafts

Gallery: 
https://mwpw-161845--mas--adobecom.hlx.live/gallery/ccd.html?milolibs=mwpw-161845--milo--adobecom 
