### PR TITLE
MWPW-165152: Splash screen / content nav URL handling

### DIFF
--- a/studio/src/mas-side-nav.js
+++ b/studio/src/mas-side-nav.js
@@ -4,6 +4,7 @@ import { navigateToPage } from './store.js';
 class MasSideNav extends LitElement {
     static styles = css`
         side-nav {
+            height: 100%;
             grid-column: 1 / 2;
             display: flex;
             flex-direction: column;
@@ -68,6 +69,13 @@ class MasSideNav extends LitElement {
         }
     `;
 
+    navigateToSplash() {
+        const url = new URL(window.location.href);
+        url.searchParams.set('page', 'welcome');
+        history.pushState({}, '', url.toString());
+        navigateToPage('splash')();
+    }
+
     render() {
         return html`<side-nav>
             <div class="dropdown-container">
@@ -77,7 +85,7 @@ class MasSideNav extends LitElement {
                 <sp-sidenav-item
                     label="Home"
                     value="home"
-                    @click="${navigateToPage('splash')}"
+                    @click="${this.navigateToSplash}"
                     selected
                 >
                     <sp-icon-home slot="icon"></sp-icon-home>

--- a/studio/src/mas-splash-screen.js
+++ b/studio/src/mas-splash-screen.js
@@ -31,6 +31,13 @@ class MasSplashScreen extends LitElement {
         openOfferSelectorTool();
     }
 
+    navigateToContent() {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('page');
+        history.replaceState({}, '', url.toString());
+        navigateToPage('content')();
+    }
+
     render() {
         return html`<div id="splash-container">
             <h1>Welcome, ${this.userName}</h1>
@@ -39,7 +46,7 @@ class MasSplashScreen extends LitElement {
                 <div class="actions-grid">
                     <div
                         class="quick-action-card"
-                        @click=${navigateToPage('content')}
+                        @click=${this.navigateToContent}
                         heading="Go to Content"
                     >
                         <div slot="cover-photo">${contentIcon}</div>

--- a/studio/src/store.js
+++ b/studio/src/store.js
@@ -7,6 +7,16 @@ import { reactiveStore } from './reactivity/reactive-store.js';
 const initialSearch = MasSearch.fromHash();
 const initialFilters = MasFilters.fromHash();
 
+const url = new URL(window.location.href);
+const pageParam = url.searchParams.get('page');
+
+const initialPage =
+    pageParam === 'welcome'
+        ? 'splash'
+        : initialSearch.query || initialSearch.path
+          ? 'content'
+          : 'splash';
+
 const Store = {
     fragments: {
         list: {
@@ -31,7 +41,7 @@ const Store = {
     ), // 'render' | 'table'
     selecting: reactiveStore(false),
     selection: reactiveStore([]),
-    currentPage: reactiveStore(initialSearch.query ? 'content' : 'splash'), // 'splash' | 'content'
+    currentPage: reactiveStore(initialPage), // 'splash' | 'content'
 };
 
 export default Store;

--- a/studio/src/store.js
+++ b/studio/src/store.js
@@ -13,7 +13,7 @@ const pageParam = url.searchParams.get('page');
 const initialPage =
     pageParam === 'welcome'
         ? 'splash'
-        : initialSearch.query || initialSearch.path
+        : initialSearch.path
           ? 'content'
           : 'splash';
 

--- a/studio/src/studio.js
+++ b/studio/src/studio.js
@@ -12,7 +12,7 @@ import './mas-toast.js';
 import './mas-hash-manager.js';
 import './mas-splash-screen.js';
 import StoreController from './reactivity/store-controller.js';
-import Store from './store.js';
+import Store, { navigateToPage } from './store.js';
 
 const BUCKET_TO_ENV = {
     e155390: 'qa',
@@ -54,6 +54,25 @@ class MasStudio extends LitElement {
         return html`<mas-splash-screen
             base-url=${this.baseUrl}
         ></mas-splash-screen>`;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+    }
+
+    handleInitialPageLoad() {
+        const url = new URL(window.location.href);
+        const pageParam = url.searchParams.get('page');
+
+        if (pageParam === 'welcome') {
+            navigateToPage('splash')();
+            history.pushState({}, '', url.toString());
+            return;
+        } else {
+            url.searchParams.delete('page');
+            history.replaceState({}, '', url.toString());
+            navigateToPage('content')();
+        }
     }
 
     render() {


### PR DESCRIPTION
This PR improves URL handling and navigation between splash screen and content navigation, specifically introduces the following criteria:

- When URL has no hashes or searchParams, user is taken to Splash screen (assumes there is no data query).
- When a hash is part of the URL, user is taken to content navigation (for querying or searching content directly).
- When user clicks on "Home" in side nav, user is taken to splash screen and `page=welcome` searchParam is added to URL  (query and path are kept for context).
- when user clicks on "Go To Content" in Splash screen, user is taken to content navigation screen and `page=welcome` is removed from URL.
- When Studio URL has `?page=welcome`, user is taken directly to Splash screen (assuming it's intended).

This allows querying data within studio with URL params bypassing splash screen while letting the user navigate to splash screen when intended.

Resolves [MWPW-165152](https://jira.corp.adobe.com/browse/MWPW-165152)

Test URLs:
- Before: https://main--mas--adobecom.hlx.live/studio.html
- After: https://mwpw-165152--mas--adobecom.hlx.live/studio.html
