### PR TITLE
MWPW-167038: OSI filed in Card Editor

### DIFF
--- a/studio/src/aem/aem-tag-picker-field.js
+++ b/studio/src/aem/aem-tag-picker-field.js
@@ -103,7 +103,6 @@ class AemTagPickerField extends LitElement {
 
     _onOstSelect = ({ detail: { offer } }) => {
         const { offer_type, planType, market_segments } = offer;
-        console.log(offer);
         this.value = '';
         const extractedOffer = {
             offer_type,
@@ -113,7 +112,6 @@ class AemTagPickerField extends LitElement {
                     ? market_segments[0]
                     : market_segments,
         };
-        console.log(extractedOffer);
         const convertCamelToSnake = (str) => {
             return str.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
         };

--- a/studio/src/constants.js
+++ b/studio/src/constants.js
@@ -37,6 +37,7 @@ export const EVENT_KEYUP = 'keyup';
 export const EVENT_FRAGMENT_CHANGE = 'fragment:change';
 
 export const EVENT_OST_SELECT = 'ost-select';
+export const EVENT_OST_OFFER_SELECT = 'ost-offer-select';
 
 export const OPERATIONS = {
     DELETE: 'delete',

--- a/studio/src/editors/merch-card-editor.js
+++ b/studio/src/editors/merch-card-editor.js
@@ -4,6 +4,7 @@ import '../fields/multifield.js';
 import '../fields/mnemonic-field.js';
 import '../aem/aem-tag-picker-field.js';
 import './variant-picker.js';
+import '../rte/osi-field.js'
 
 const MODEL_PATH = '/conf/mas/settings/dam/cfm/models/card';
 
@@ -218,6 +219,13 @@ class MerchCardEditor extends LitElement {
                     @change="${this.updateFragment}"
                     >${unsafeHTML(form.ctas.values[0])}</rte-field
                 >
+            </sp-field-group>
+            <sp-field-group>
+                <sp-field-label for="osi-field">OSI</sp-field-label>
+                <osi-field
+                    id="osi-field"
+                    data-field="osi-field"
+                ></osi-field>
             </sp-field-group>
             <aem-tag-picker-field
                 label="Tags"

--- a/studio/src/rte/osi-field.js
+++ b/studio/src/rte/osi-field.js
@@ -1,0 +1,83 @@
+import { LitElement, html, css } from 'lit';
+import { EVENT_OST_OFFER_SELECT } from '../constants.js';
+import { openOfferSelectorTool, closeOfferSelectorTool } from './ost.js';
+
+let osiFieldSource;
+
+class OsiField extends LitElement {
+    static properties = {
+        selectedOffer: { type: String },
+        showOfferSelector: { type: String },
+    };
+
+    #boundHandlers;
+    constructor() {
+        super();
+        this.selectedOffer = '';
+        this.showOfferSelector = false;
+        this.#boundHandlers = {
+            ostEvent: this.#handleOstEvent.bind(this),
+        };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        document.addEventListener(
+            EVENT_OST_OFFER_SELECT,
+            this.#boundHandlers.ostEvent,
+        );
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        document.removeEventListener(
+            EVENT_OST_OFFER_SELECT,
+            this.#boundHandlers.ostEvent,
+        );
+    }
+
+    #handleOstEvent({ detail: { offerSelectorId, offer } }) {
+        if (osiFieldSource !== this) return;
+        this.selectedOffer = offerSelectorId;
+        this.showOfferSelector = false;
+        osiFieldSource = null;
+        closeOfferSelectorTool();
+    }
+
+    get #offerSelectorToolButton() {
+        return html`
+            <sp-divider size="s" horizontal></sp-divider>
+            <sp-action-button
+                emphasized
+                id="offerSelectorToolButtonOSI"
+                @click=${this.handleOpenOfferSelector}
+                title="Offer Selector Tool"
+            >
+                <sp-icon-shopping-cart slot="icon"></sp-icon-shopping-cart>
+            </sp-action-button>
+        `;
+    }
+
+    handleOpenOfferSelector(event, element) {
+        osiFieldSource = this;
+        this.showOfferSelector = true;
+        openOfferSelectorTool(this, element);
+    }
+
+    render() {
+        return html`
+            <div>
+                <sp-action-group
+                    quiet
+                    size="m"
+                    aria-label="RTE toolbar actions"
+                >
+                    ${this.#offerSelectorToolButton}
+                </sp-action-group>
+                <p>Selected Offer: <strong>${this.selectedOffer}</strong></p>
+            </div>
+        `;
+    }
+}
+
+customElements.define('osi-field', OsiField);

--- a/studio/src/rte/osi-field.js
+++ b/studio/src/rte/osi-field.js
@@ -40,7 +40,6 @@ class OsiField extends LitElement {
         if (osiFieldSource !== this) return;
         this.selectedOffer = offerSelectorId;
         this.showOfferSelector = false;
-        osiFieldSource = null;
         closeOfferSelectorTool();
     }
 

--- a/studio/src/rte/ost.js
+++ b/studio/src/rte/ost.js
@@ -2,6 +2,7 @@ import { html } from 'lit';
 import {
     CHECKOUT_CTA_TEXTS,
     EVENT_OST_SELECT,
+    EVENT_OST_OFFER_SELECT,
     WCS_LANDSCAPE_PUBLISHED,
     WCS_LANDSCAPE_DRAFT,
 } from '../constants.js';
@@ -126,7 +127,7 @@ const OST_VALUE_MAPPING = {
     false: false,
 };
 
-export function onSelect(offerSelectorId, type, offer, options, promoOverride) {
+export function onPlaceholderSelect(offerSelectorId, type, offer, options, promoOverride) {
     const changes = getObjectDifference(options, OST_OPTION_DEFAULTS);
 
     const attributes = { 'data-wcs-osi': offerSelectorId };
@@ -159,6 +160,15 @@ export function onSelect(offerSelectorId, type, offer, options, promoOverride) {
     ostRoot.dispatchEvent(
         new CustomEvent(EVENT_OST_SELECT, {
             detail: attributes,
+            bubbles: true,
+        }),
+    );
+}
+
+export function onOfferSelect(offerSelectorId, type, offer) {
+    ostRoot.dispatchEvent(
+        new CustomEvent(EVENT_OST_OFFER_SELECT, {
+            detail: { offerSelectorId, offer },
             bubbles: true,
         }),
     );

--- a/studio/src/rte/ost.js
+++ b/studio/src/rte/ost.js
@@ -174,7 +174,7 @@ export function getOffferSelectorTool() {
     `;
 }
 
-export function openOfferSelectorTool(offerElement) {
+export function openOfferSelectorTool(triggerElement, offerElement) {
     const landscape =
         Store.commerceEnv?.value == 'stage'
             ? WCS_LANDSCAPE_DRAFT
@@ -235,7 +235,10 @@ export function openOfferSelectorTool(offerElement) {
         defaultPlaceholderOptions,
         offerSelectorPlaceholderOptions,
         dialog: true,
-        onSelect,
+        onSelect:
+        triggerElement.tagName === 'OSI-FIELD'
+            ? onOfferSelect
+            : onPlaceholderSelect,
     });
 }
 

--- a/studio/src/rte/rte-field.js
+++ b/studio/src/rte/rte-field.js
@@ -712,7 +712,7 @@ class RteField extends LitElement {
     handleOpenOfferSelector(event, element) {
         ostRteFieldSource = this;
         this.showOfferSelector = true;
-        openOfferSelectorTool(element);
+        openOfferSelectorTool(this, element);
     }
 
     get #linkEditorButton() {


### PR DESCRIPTION
Adding OSI field in merch card editor

- Opening pr for easier communication and suggestions
- Still need to add logic to post osi-field value in odin and to read from it when card editor opens
- Right now tags added by selecting an offer will overwrite any previously added tags on card, how to approach this?

Resolve: https://jira.corp.adobe.com/browse/MWPW-167038

Test URLs:
- Before: https://main--mas--adobecom.aem.live/studio.html
- After: https://MWPW-167038--mas--adobecom.aem.live/studio.html
