### PR TITLE
MWPW-167655: Hide un-rendering cards from end users

### DIFF
--- a/studio/src/mas-recently-updated.js
+++ b/studio/src/mas-recently-updated.js
@@ -35,14 +35,13 @@ class MasRecentlyUpdated extends LitElement {
             <div id="recently-updated-container" ?loading=${this.loading.value}>
                 ${this.loadingIndicator}
                 ${this.fragments.value.map((fragmentStore) => {
-                    return html` ${variantValues.includes(
-                        fragmentStore.value.variant,
-                    )
-                        ? html`<mas-fragment
-                              .store=${fragmentStore}
-                              view="render"
-                          ></mas-fragment>`
-                        : html``}`;
+                    if (!variantValues.includes(fragmentStore.value.variant))
+                        return html``;
+
+                    return html`<mas-fragment
+                        .store=${fragmentStore}
+                        view="render"
+                    ></mas-fragment>`;
                 })}
             </div>`;
     }

--- a/studio/src/mas-recently-updated.js
+++ b/studio/src/mas-recently-updated.js
@@ -35,6 +35,7 @@ class MasRecentlyUpdated extends LitElement {
             <div id="recently-updated-container" ?loading=${this.loading.value}>
                 ${this.loadingIndicator}
                 ${this.fragments.value.map((fragmentStore) => {
+                    // Hide the card if the variant isn't one of VARIANTS that is pre-defined.
                     if (!variantValues.includes(fragmentStore.value.variant))
                         return html``;
 

--- a/studio/src/mas-recently-updated.js
+++ b/studio/src/mas-recently-updated.js
@@ -2,6 +2,7 @@ import { html, LitElement, nothing } from 'lit';
 import Store from './store.js';
 import StoreController from './reactivity/store-controller.js';
 import { VARIANTS } from './editors/variant-picker.js';
+
 class MasRecentlyUpdated extends LitElement {
     static get properties() {
         return {

--- a/studio/src/mas-recently-updated.js
+++ b/studio/src/mas-recently-updated.js
@@ -1,7 +1,7 @@
 import { html, LitElement, nothing } from 'lit';
 import Store from './store.js';
 import StoreController from './reactivity/store-controller.js';
-
+import { VARIANTS } from './editors/variant-picker.js';
 class MasRecentlyUpdated extends LitElement {
     static get properties() {
         return {
@@ -29,16 +29,20 @@ class MasRecentlyUpdated extends LitElement {
     }
 
     render() {
+        const variantValues = VARIANTS.map((v) => v.value);
         return html`<h2>Recently Updated</h2>
             <div id="recently-updated-container" ?loading=${this.loading.value}>
                 ${this.loadingIndicator}
-                ${this.fragments.value.map(
-                    (fragmentStore) =>
-                        html`<mas-fragment
-                            .store=${fragmentStore}
-                            view="render"
-                        ></mas-fragment>`,
-                )}
+                ${this.fragments.value.map((fragmentStore) => {
+                    return html` ${variantValues.includes(
+                        fragmentStore.value.variant,
+                    )
+                        ? html`<mas-fragment
+                              .store=${fragmentStore}
+                              view="render"
+                          ></mas-fragment>`
+                        : html``}`;
+                })}
             </div>`;
     }
 }


### PR DESCRIPTION
Hide un-rendering cards from end users by checking their variants.

Resolve: [MWPW-167655](https://jira.corp.adobe.com/browse/MWPW-167655)

Test URLs:
- Before: https://main--mas--adobecom.aem.live/studio.html
- After: https://MWPW-167655--mas--adobecom.aem.live/studio.html
