### PR TITLE
MWPW-164492: fix stock

### DIFF
--- a/studio/src/editors/merch-card-editor.js
+++ b/studio/src/editors/merch-card-editor.js
@@ -229,15 +229,17 @@ class MerchCardEditor extends LitElement {
                     >${unsafeHTML(form.callout?.values[0])}</rte-field
                 >
             </sp-field-group>
-            <sp-checkbox
-                size="m"
-                data-field="showStockCheckbox"
-                value="${form.showStockCheckbox?.values[0]}"
-                .checked="${form.showStockCheckbox?.values[0]}"
-                @change="${this.updateFragment}"
-                ?disabled=${this.disabled}
-                >Stock Checkbox</sp-checkbox
-            >
+            <sp-field-group class="toggle" id="stockOffer">
+                <sp-checkbox
+                    size="m"
+                    data-field="showStockCheckbox"
+                    value="${form.showStockCheckbox?.values[0]}"
+                    .checked="${form.showStockCheckbox?.values[0]}"
+                    @change="${this.updateFragment}"
+                    ?disabled=${this.disabled}
+                    >Stock Checkbox</sp-checkbox
+                >
+            </sp-field-group>
             <sp-field-group class="toggle" id="ctas">
                 <sp-field-label for="ctas">Footer</sp-field-label>
                 <rte-field


### PR DESCRIPTION
Hide stock checkbox on other cards than Plans,
small change with no impact so will merge immediately.

Resolve MWPW-164492

Test URLs:
- Before: https://main--mas--adobecom.aem.live/studio.html
- After: https://<branch>--mas--adobecom.aem.live/studio.html
