### PR TITLE
Nala: skip test for daily run

### DIFF
--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -25,7 +25,7 @@ test.beforeEach(async ({ page, browserName }) => {
 
 test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
     // @studio-try-buy-widget-editor - Validate editor fields for try buy widget card in mas studio
-    test(`${features[0].name},${features[0].tags}`, async ({
+    test.skip(`${features[0].name},${features[0].tags}`, async ({
         page,
         baseURL,
     }) => {


### PR DESCRIPTION
While `@nopr` tag skips tests on PR runs, it does not skip it on daily run. Adding to skip the test entirely until AH milo PR is merged when the test will be reactivated.

@Roycethan

Resolve

Test URLs:
- Before: https://main--mas--adobecom.aem.live
- After: https://MWPW-111111--mas--adobecom.aem.live
