### PR TITLE
MWPW-168729: [3-in-1] Audit to find all the iframes used in Milo

### DIFF
--- a/ost-audit/README.md
+++ b/ost-audit/README.md
@@ -15,6 +15,8 @@ script that crawls through raw EDS html versions of page for OST links and spits
  for a full configured set of URLs and/or sitemap you can use -m parameter with a manifest composed of URLs/Sitemap separated by new lines character
  
  for faster execution, buffer size (number of parallel page being audited) can be increased but will impact your connection with parameter -b (you can move it lower to the default that is 100).
+
+ to seach for links that open commerce modals (CRM, D2P and TwP) add the `-t modal` to the command.
  
  so typical execution could be 
  `node audit.mjs -b 50 -f ~/Documents/audit.csv -m ./audit-manifest.txt`


### PR DESCRIPTION
I slightly refactored the audit script and added an option to set the audit target using the -t parameter.

By default, the target is OST, so you don’t need to specify -t. But if you set -t modal, the script will look for links where the href contains either mini-plans or modals-content-rich. When using this target, searching by a specific phrase isn’t supported (it is not needed for now)

Resolves [MWPW-168729](https://jira.corp.adobe.com/browse/MWPW-168729)

Test URLs:
- Before: https://main--mas--adobecom.aem.live/studio.html
- After: https://mwpw-168729--mas--adobecom.aem.live/studio.html
