### PR TITLE
MWPW-169619: fix stale IMS session issue

### DIFF
--- a/studio.html
+++ b/studio.html
@@ -87,12 +87,21 @@
                     console.error('[M@S Studio] IMS error: ', error);
                 },
                 onReady() {
-                    if (adobeIMS.isSignedInUser()) {
-                        console.info('[M@S Studio] IMS is ready, signed in');
-                    } else {
-                        console.info('[M@S Studio] IMS is ready, signing in');
-                        adobeIMS.signIn();
-                    }
+                    adobeIMS
+                        .refreshToken()
+                        .then(() => {
+                            console.info(
+                                '[M@S Studio] IMS is ready, signed in',
+                            );
+                        })
+                        .catch((e) => {
+                            console.error(
+                                '[M@S Studio] failed to refresh IMS token: ',
+                                e,
+                            );
+                            console.info('[M@S Studio] Signing in');
+                            adobeIMS.signIn();
+                        });
                 },
             };
         </script>


### PR DESCRIPTION
With this PR, we force IMS to refresh token, if the IMS session is stale, it will error out and the user will be redirected to IMS sign-in flow.

Resolve: MWPW-169619

Test URLs:
- Before: https://main--mas--adobecom.aem.live/studio.html
- After: https://mwpw-169619--mas--adobecom.aem.live/studio.html
