### PR TITLE
MWPW-169148 [Nala]: Validate CTA variant change

### DIFF
--- a/nala/libs/webutil.js
+++ b/nala/libs/webutil.js
@@ -2,8 +2,6 @@
 
 import { expect, request } from '@playwright/test';
 
-// const { request } = require('@playwright/test');
-
 /**
  * A utility class for common web interactions.
  */

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_discard.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_discard.spec.js
@@ -25,7 +25,7 @@ export default {
         },
         {
             tcid: '2',
-            name: '@studio-try-buy-widget-discard-change-osi',
+            name: '@studio-try-buy-widget-discard-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_discard.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_discard.spec.js
@@ -42,5 +42,17 @@ export default {
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-discard',
         },
+        {
+            tcid: '3',
+            name: '@studio-try-buy-widget-discard-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',
+                variant: 'secondary',
+                newVariant: 'secondary-outline',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-try-buy-widget @ccd-try-buy-widget-discard',
+        },
     ],
 };

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_discard.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_discard.spec.js
@@ -52,7 +52,7 @@ export default {
                 newVariant: 'secondary-outline',
             },
             browserParams: '#query=',
-            tags: '@mas-studio @ccd @ccd-try-buy-widget @ccd-try-buy-widget-discard',
+            tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-discard',
         },
     ],
 };

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_edit.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_edit.spec.js
@@ -187,7 +187,7 @@ export default {
                 },
             },
             browserParams: '#query=',
-            tags: '@mas-studio @ccd @ccd-try-buy-widget @ccd-try-buy-widget-edit',
+            tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-edit',
         },
     ],
 };

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_edit.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_edit.spec.js
@@ -111,6 +111,12 @@ export default {
                 cardid: '02ee0d3c-a472-44a1-b15a-f65c24eefc4b',
                 ctaText: 'Free trial',
                 newCtaText: 'Save now',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
+                ucv3: 'commerce.adobe.com/store/email',
+                country: 'US',
+                ctx: 'fp',
+                lang: 'en',
+                client: 'adobe_com',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-edit',
@@ -121,6 +127,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '02ee0d3c-a472-44a1-b15a-f65c24eefc4b',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-edit',
@@ -131,6 +138,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '02ee0d3c-a472-44a1-b15a-f65c24eefc4b',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-edit',
@@ -176,6 +184,7 @@ export default {
             data: {
                 cardid: '02ee0d3c-a472-44a1-b15a-f65c24eefc4b',
                 variant: 'secondary',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
                 ctaCSS: {
                     'background-color': 'rgb(230, 230, 230)',
                     color: 'rgb(34, 34, 34)',

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_edit.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_edit.spec.js
@@ -152,7 +152,7 @@ export default {
         },
         {
             tcid: '12',
-            name: '@studio-try-buy-widget-change-osi',
+            name: '@studio-try-buy-widget-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',
@@ -168,6 +168,26 @@ export default {
             },
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-edit',
+        },
+        {
+            tcid: '13',
+            name: '@studio-try-buy-widget-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '02ee0d3c-a472-44a1-b15a-f65c24eefc4b',
+                variant: 'secondary',
+                ctaCSS: {
+                    'background-color': 'rgb(230, 230, 230)',
+                    color: 'rgb(34, 34, 34)',
+                },
+                newVariant: 'secondary-outline',
+                newCtaCSS: {
+                    'background-color': 'rgba(0, 0, 0, 0)',
+                    color: 'rgb(34, 34, 34)',
+                },
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-try-buy-widget @ccd-try-buy-widget-edit',
         },
     ],
 };

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
@@ -34,7 +34,7 @@ export default {
         },
         {
             tcid: '3',
-            name: '@studio-try-buy-widget-save-change-osi',
+            name: '@studio-try-buy-widget-save-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
@@ -3,7 +3,7 @@ export default {
     features: [
         {
             tcid: '0',
-            name: '@studio-try-buy-widget-edit-save',
+            name: '@studio-try-buy-widget-save-edit-size',
             path: '/studio.html',
             data: {
                 cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
@@ -18,6 +18,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',
+                osi: 'Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-save',
@@ -28,6 +29,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',
+                osi: 'Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-save',
@@ -57,6 +59,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',
+                osi: 'Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ',
                 variant: 'secondary',
                 ctaCSS: {
                     'background-color': 'rgb(230, 230, 230)',

--- a/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
+++ b/nala/studio/ahome/try-buy-widget/specs/try_buy_widget_save.spec.js
@@ -51,5 +51,25 @@ export default {
             browserParams: '#query=',
             tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-save',
         },
+        {
+            tcid: '4',
+            name: '@studio-try-buy-widget-save-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '2d9025f7-ea56-4eeb-81b2-a52762358b9d',
+                variant: 'secondary',
+                ctaCSS: {
+                    'background-color': 'rgb(230, 230, 230)',
+                    color: 'rgb(34, 34, 34)',
+                },
+                newVariant: 'secondary-outline',
+                newCtaCSS: {
+                    'background-color': 'rgba(0, 0, 0, 0)',
+                    color: 'rgb(34, 34, 34)',
+                },
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ahome @ahome-try-buy-widget @ahome-try-buy-widget-save',
+        },
     ],
 };

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
@@ -171,7 +171,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
         });
     });
 
-    // @studio-try-buy-widget-discard-change-osi - Validate changing OSI for AH try-buy-widget card in mas studio
+    // @studio-try-buy-widget-discard-edit-osi - Validate changing OSI for AH try-buy-widget card in mas studio
     test(`${features[2].name},${features[2].tags}`, async ({
         page,
         baseURL,
@@ -189,7 +189,9 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.cardid, 'ahtrybuywidget-double'),
             ).toBeVisible();
-            await (await studio.getCard(data.cardid, 'ahtrybuywidget-double')).dblclick();
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget-double')
+            ).dblclick();
             await expect(await studio.editorPanel).toBeVisible();
         });
 
@@ -246,7 +248,9 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
         });
 
         await test.step('step-4: Open the editor and validate there are no changes', async () => {
-            await (await studio.getCard(data.cardid, 'ahtrybuywidget-double')).dblclick();
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget-double')
+            ).dblclick();
             await expect(await studio.editorPanel).toBeVisible();
             await expect(await studio.editorOSI).toContainText(data.osi);
             await expect(await studio.editorOSI).not.toContainText(data.newosi);

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
@@ -286,7 +286,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
     });
 
     // @studio-try-buy-widget-discard-edit-cta-variant - Validate changing CTA variant for AH try-buy-widget card in mas studio
-    test(`${features[3].name},${features[3].tags}`, async ({
+    test.skip(`${features[3].name},${features[3].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
@@ -285,7 +285,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
         });
     });
 
-    // @studio-try-buy-widget-discard-edit-cta-variant - Validate changing cta variant for AH try-buy-widget card in mas studio
+    // @studio-try-buy-widget-discard-edit-cta-variant - Validate changing CTA variant for AH try-buy-widget card in mas studio
     test(`${features[3].name},${features[3].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_discard.test.js
@@ -284,4 +284,79 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             );
         });
     });
+
+    // @studio-try-buy-widget-discard-edit-cta-variant - Validate changing cta variant for AH try-buy-widget card in mas studio
+    test(`${features[3].name},${features[3].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[3];
+        const testPage = `${baseURL}${features[3].path}${miloLibs}${features[3].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'ahtrybuywidget-double'),
+            ).toBeVisible();
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget-double')
+            ).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Edit CTA variant', async () => {
+            await expect(
+                await studio.editorPanel
+                    .locator(studio.editorFooter)
+                    .locator(studio.linkEdit),
+            ).toBeVisible();
+            await expect(await studio.editorCTA.first()).toBeVisible();
+            await expect(await studio.editorCTA.first()).toHaveClass(
+                data.variant,
+            );
+            await studio.editorCTA.first().click();
+            await studio.editorPanel
+                .locator(studio.editorFooter)
+                .locator(studio.linkEdit)
+                .click();
+            await expect(await studio.linkVariant).toBeVisible();
+            await expect(await studio.linkSave).toBeVisible();
+            await expect(
+                await studio.getLinkVariant(data.newVariant),
+            ).toBeVisible();
+            await (await studio.getLinkVariant(data.newVariant)).click();
+            await studio.linkSave.click();
+            await expect(await studio.editorCTA.first()).toHaveClass(
+                data.newVariant,
+            );
+        });
+
+        await test.step('step-4: Close the editor and verify discard is triggered', async () => {
+            await studio.editorPanel.locator(studio.closeEditor).click();
+            await expect(
+                await studio.editorPanel.locator(studio.confirmationDialog),
+            ).toBeVisible();
+            await studio.editorPanel.locator(studio.discardDialog).click();
+            await expect(await studio.editorPanel).not.toBeVisible();
+        });
+
+        await test.step('step-4: Open the editor and validate there are no changes', async () => {
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget-double')
+            ).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+            await expect(await studio.editorCTA.first()).toBeVisible();
+            await expect(await studio.editorCTA.first()).toHaveClass(
+                data.variant,
+            );
+            await expect(await studio.editorCTA.first()).not.toHaveClass(
+                data.newVariant,
+            );
+        });
+    });
 });

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -986,7 +986,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
     });
 
     // @studio-try-buy-widget-edit-cta-variant - Validate edit CTA variant for try-buy-widget card in mas studio
-    test(`${features[13].name},${features[13].tags}`, async ({
+    test.skip(`${features[13].name},${features[13].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -4,8 +4,8 @@ import AHTryBuyWidgetSpec from '../specs/try_buy_widget_edit.spec.js';
 import AHTryBuyWidgetPage from '../try-buy-widget.page.js';
 import CCDSlicePage from '../../../ccd/slice/slice.page.js';
 import CCDSuggestedPage from '../../../ccd/suggested/suggested.page.js';
-
 import OSTPage from '../../../ost.page.js';
+import WebUtil from '../../../../libs/webutil.js';
 
 const { features } = AHTryBuyWidgetSpec;
 const miloLibs = process.env.MILO_LIBS || '';
@@ -15,6 +15,7 @@ let slice;
 let suggested;
 let trybuywidget;
 let ost;
+let webUtil;
 
 test.beforeEach(async ({ page, browserName }) => {
     test.slow();
@@ -28,6 +29,7 @@ test.beforeEach(async ({ page, browserName }) => {
     suggested = new CCDSuggestedPage(page);
     trybuywidget = new AHTryBuyWidgetPage(page);
     ost = new OSTPage(page);
+    webUtil = new WebUtil(page);
 });
 
 test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
@@ -794,7 +796,9 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.cardid, 'ahtrybuywidget-triple'),
             ).toBeVisible();
-            await (await studio.getCard(data.cardid, 'ahtrybuywidget-triple')).dblclick();
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget-triple')
+            ).dblclick();
             await expect(await studio.editorPanel).toBeVisible();
         });
 
@@ -853,7 +857,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
         });
     });
 
-    // @studio-try-buy-widget-change-osi - Validate changing OSI for try-buy-widget card in mas studio
+    // @studio-try-buy-widget-edit-osi - Validate changing OSI for try-buy-widget card in mas studio
     test(`${features[12].name},${features[12].tags}`, async ({
         page,
         baseURL,
@@ -871,7 +875,9 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.cardid, 'ahtrybuywidget-double'),
             ).toBeVisible();
-            await (await studio.getCard(data.cardid, 'ahtrybuywidget-double')).dblclick();
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget-double')
+            ).dblclick();
             await expect(await studio.editorPanel).toBeVisible();
         });
 
@@ -938,6 +944,79 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                 'value',
                 new RegExp(`${data.marketSegmentsTag}`),
             );
+        });
+    });
+
+    // @studio-try-buy-widget-edit-cta-variant - Validate edit CTA variant for try-buy-widget card in mas studio
+    test(`${features[13].name},${features[13].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[13];
+        const testPage = `${baseURL}${features[13].path}${miloLibs}${features[13].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'ahtrybuywidget-triple'),
+            ).toBeVisible();
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget-triple')
+            ).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Edit CTA link', async () => {
+            await expect(
+                await studio.editorPanel
+                    .locator(studio.editorFooter)
+                    .locator(studio.linkEdit),
+            ).toBeVisible();
+            await expect(await studio.editorCTA.first()).toBeVisible();
+            await expect(await studio.editorCTA.first()).toHaveClass(
+                data.variant,
+            );
+            expect(
+                await webUtil.verifyCSS(
+                    await trybuywidget.cardCTA.first(),
+                    data.ctaCSS,
+                ),
+            ).toBeTruthy();
+            await studio.editorCTA.first().click();
+            await studio.editorPanel
+                .locator(studio.editorFooter)
+                .locator(studio.linkEdit)
+                .click();
+            await expect(await studio.linkVariant).toBeVisible();
+            await expect(await studio.linkSave).toBeVisible();
+            await expect(
+                await studio.getLinkVariant(data.newVariant),
+            ).toBeVisible();
+            await (await studio.getLinkVariant(data.newVariant)).click();
+            await studio.linkSave.click();
+        });
+
+        await test.step('step-4: Validate edited CTA Link in Editor panel', async () => {
+            await expect(await studio.editorCTA.first()).toHaveClass(
+                data.newVariant,
+            );
+            await expect(await studio.editorCTA.first()).not.toHaveClass(
+                data.variant,
+            );
+        });
+
+        await test.step('step-5: Validate edited CTA on the card', async () => {
+            expect(
+                await webUtil.verifyCSS(
+                    await trybuywidget.cardCTA.first(),
+                    data.newCtaCSS,
+                ),
+            ).toBeTruthy();
         });
     });
 });

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -547,7 +547,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(await studio.editorPanel).toBeVisible();
         });
 
-        await test.step('step-3: Edit price field', async () => {
+        await test.step('step-3: Edit CTA field', async () => {
             await expect(
                 await studio.editorPanel.locator(studio.editorFooter),
             ).toBeVisible();
@@ -589,6 +589,26 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(await trybuywidget.cardCTASlot).toContainText(
                 data.newCtaText,
             );
+            await expect(await trybuywidget.cardCTA.first()).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await trybuywidget.cardCTA.first()).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
+
+            const CTAhref = await trybuywidget.cardCTA.first().getAttribute('data-href');
+            let workflowStep = decodeURI(CTAhref).split('?')[0];
+            let searchParams = new URLSearchParams(
+                decodeURI(CTAhref).split('?')[1],
+            );
+
+            expect(workflowStep).toContain(data.ucv3);
+            expect(searchParams.get('co')).toBe(data.country);
+            expect(searchParams.get('ctx')).toBe(data.ctx);
+            expect(searchParams.get('lang')).toBe(data.lang);
+            expect(searchParams.get('cli')).toBe(data.client);
         });
     });
 
@@ -679,8 +699,16 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                 await studio.getCard(data.cardid, 'ahtrybuywidget-triple'),
             ).not.toBeVisible();
             await expect(await slice.cardDescription).toBeVisible();
-            await expect(await slice.cardCTA.first()).toBeVisible();
             await expect(await slice.cardIcon).toBeVisible();
+            await expect(await slice.cardCTA.first()).toBeVisible();
+            await expect(await slice.cardCTA.first()).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await slice.cardCTA.first()).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -773,8 +801,16 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(await suggested.cardTitle).toBeVisible();
             await expect(await suggested.cardDescription).toBeVisible();
             await expect(await suggested.cardPrice).toBeVisible();
-            await expect(await suggested.cardCTA.first()).toBeVisible();
             await expect(await suggested.cardIcon).toBeVisible();
+            await expect(await suggested.cardCTA.first()).toBeVisible();
+            await expect(await suggested.cardCTA.first()).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await suggested.cardCTA.first()).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -1017,6 +1053,14 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
+            await expect(await trybuywidget.cardCTA.first()).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await trybuywidget.cardCTA.first()).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 });

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -971,7 +971,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(await studio.editorPanel).toBeVisible();
         });
 
-        await test.step('step-3: Edit CTA link', async () => {
+        await test.step('step-3: Edit CTA variant', async () => {
             await expect(
                 await studio.editorPanel
                     .locator(studio.editorFooter)

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -1001,7 +1001,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await studio.linkSave.click();
         });
 
-        await test.step('step-4: Validate edited CTA Link in Editor panel', async () => {
+        await test.step('step-4: Validate edited CTA variant in Editor panel', async () => {
             await expect(await studio.editorCTA.first()).toHaveClass(
                 data.newVariant,
             );

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -598,7 +598,9 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                 'checkout-button',
             );
 
-            const CTAhref = await trybuywidget.cardCTA.first().getAttribute('data-href');
+            const CTAhref = await trybuywidget.cardCTA
+                .first()
+                .getAttribute('data-href');
             let workflowStep = decodeURI(CTAhref).split('?')[0];
             let searchParams = new URLSearchParams(
                 decodeURI(CTAhref).split('?')[1],

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
@@ -206,14 +206,16 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'slice'),
             ).toBeVisible();
-            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA).first()).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA).first()).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await (await studio.getCard(data.clonedCardID, 'slice'))
+                    .locator(slice.cardCTA)
+                    .first(),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await (await studio.getCard(data.clonedCardID, 'slice'))
+                    .locator(slice.cardCTA)
+                    .first(),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
@@ -285,14 +287,16 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
             ).not.toBeVisible();
-            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA).first()).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA).first()).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await (await studio.getCard(data.clonedCardID, 'suggested'))
+                    .locator(suggested.cardCTA)
+                    .first(),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await (await studio.getCard(data.clonedCardID, 'suggested'))
+                    .locator(suggested.cardCTA)
+                    .first(),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
@@ -470,14 +474,12 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
-            await expect(await clonedCard.locator(trybuywidget.cardCTA).first()).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await clonedCard.locator(trybuywidget.cardCTA).first()).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await clonedCard.locator(trybuywidget.cardCTA).first(),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await clonedCard.locator(trybuywidget.cardCTA).first(),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 });

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
@@ -291,7 +291,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
         });
     });
 
-    // @studio-try-buy-widget-save-change-osi - Validate saving change osi
+    // @studio-try-buy-widget-save-edit-osi - Validate saving change osi
     test(`${features[3].name},${features[3].tags}`, async ({
         page,
         baseURL,
@@ -309,7 +309,9 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.cardid, 'ahtrybuywidget'),
             ).toBeVisible();
-            await (await studio.getCard(data.cardid, 'ahtrybuywidget')).dblclick();
+            await (
+                await studio.getCard(data.cardid, 'ahtrybuywidget')
+            ).dblclick();
             await expect(await studio.editorPanel).toBeVisible();
         });
 

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
@@ -55,7 +55,7 @@ test.afterEach(async ({ page }) => {
 });
 
 test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
-    // @studio-try-buy-widget-edit-save - Validate editing and saving try buy widjet card in mas studio
+    // @studio-try-buy-widget-save-edit-size - Validate editing and saving try buy widjet card in mas studio
     test(`${features[0].name},${features[0].tags}`, async ({
         page,
         baseURL,
@@ -98,7 +98,6 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
         await test.step('step-4: Edit a field and save', async () => {
             await studio.editorPanel.locator(studio.editorSize).click();
             await page.getByRole('option', { name: 'triple' }).click();
-            //save card
             await studio.saveCard();
         });
 
@@ -116,25 +115,13 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                 data.clonedCardID,
                 'ahtrybuywidget-triple',
             );
+            await expect(clonedCard).toBeVisible();
             await expect(
-                await studio.getCard(
-                    data.clonedCardID,
-                    'ahtrybuywidget-triple',
-                ),
+                await clonedCard.locator(trybuywidget.cardPrice),
             ).toBeVisible();
-            await expect(await trybuywidget.cardPrice).toBeVisible();
-            await expect(await trybuywidget.cardPrice).toContainText(
-                data.price,
-            );
-
-            //delete the card
-            await studio.deleteCard();
             await expect(
-                await studio.getCard(
-                    data.clonedCardID,
-                    'ahtrybuywidget-double',
-                ),
-            ).not.toBeVisible();
+                await clonedCard.locator(trybuywidget.cardPrice),
+            ).toContainText(data.price);
         });
     });
 
@@ -192,7 +179,6 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                 .click();
             await page.getByRole('option', { name: 'slice' }).click();
             await page.waitForTimeout(2000);
-            // save card
             await studio.saveCard();
         });
 
@@ -273,7 +259,6 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                 .click();
             await page.getByRole('option', { name: 'suggested' }).click();
             await page.waitForTimeout(2000);
-            // save card
             await studio.saveCard();
         });
 
@@ -351,7 +336,6 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await (await ost.nextButton).click();
             await expect(await ost.priceUse).toBeVisible();
             await ost.priceUse.click();
-            // save card
             await studio.saveCard();
         });
 
@@ -429,7 +413,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await page.waitForTimeout(2000);
         });
 
-        await test.step('step-4: Edta CTA variant and save card', async () => {
+        await test.step('step-4: Edit CTA variant and save card', async () => {
             await expect(
                 await studio.editorPanel
                     .locator(studio.editorFooter)
@@ -457,7 +441,6 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             ).toBeVisible();
             await (await studio.getLinkVariant(data.newVariant)).click();
             await studio.linkSave.click();
-            // save card
             await studio.saveCard();
         });
 

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
@@ -382,7 +382,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
         });
     });
 
-    // @studio-try-buy-widget-save-edit-cta-variant - Validate saving change cta variant
+    // @studio-try-buy-widget-save-edit-cta-variant - Validate saving change CTA variant
     test(`${features[4].name},${features[4].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
@@ -2,6 +2,8 @@ import { expect, test } from '@playwright/test';
 import StudioPage from '../../../studio.page.js';
 import AHTryBuyWidgetSpec from '../specs/try_buy_widget_save.spec.js';
 import AHTryBuyWidgetPage from '../try-buy-widget.page.js';
+import CCDSlicePage from '../../../ccd/slice/slice.page.js';
+import CCDSuggestedPage from '../../../ccd/suggested/suggested.page.js';
 import OSTPage from '../../../ost.page.js';
 import WebUtil from '../../../../libs/webutil.js';
 
@@ -10,6 +12,8 @@ const miloLibs = process.env.MILO_LIBS || '';
 
 let studio;
 let trybuywidget;
+let slice;
+let suggested;
 let ost;
 let clonedCardID;
 let webUtil;
@@ -23,6 +27,8 @@ test.beforeEach(async ({ page, browserName }) => {
     }
     studio = new StudioPage(page);
     trybuywidget = new AHTryBuyWidgetPage(page);
+    slice = new CCDSlicePage(page);
+    suggested = new CCDSuggestedPage(page);
     ost = new OSTPage(page);
     clonedCardID = '';
     webUtil = new WebUtil(page);
@@ -200,16 +206,14 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'slice'),
             ).toBeVisible();
-        });
-
-        await test.step('step-6: Delete the card', async () => {
-            await studio.deleteCard();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
-            ).not.toBeVisible();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'slice'),
-            ).not.toBeVisible();
+            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA).first()).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA).first()).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -281,16 +285,14 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
             ).not.toBeVisible();
-        });
-
-        await test.step('step-6: Delete the card', async () => {
-            await studio.deleteCard();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'suggested'),
-            ).not.toBeVisible();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
-            ).not.toBeVisible();
+            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA).first()).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA).first()).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -468,6 +470,14 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
+            await expect(await clonedCard.locator(trybuywidget.cardCTA).first()).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await clonedCard.locator(trybuywidget.cardCTA).first()).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 });

--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_save.test.js
@@ -373,7 +373,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
     });
 
     // @studio-try-buy-widget-save-edit-cta-variant - Validate saving change CTA variant
-    test(`${features[4].name},${features[4].tags}`, async ({
+    test.skip(`${features[4].name},${features[4].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ahome/try-buy-widget/try-buy-widget.page.js
+++ b/nala/studio/ahome/try-buy-widget/try-buy-widget.page.js
@@ -14,5 +14,6 @@ export default class TryBuyWidgetPage {
             'span[data-template="price"] > .price-strikethrough',
         );
         this.cardCTASlot = page.locator('div[slot="cta"]');
+        this.cardCTA = page.locator('div[slot="cta"] > button');
     }
 }

--- a/nala/studio/ccd/slice/slice.page.js
+++ b/nala/studio/ccd/slice/slice.page.js
@@ -71,9 +71,8 @@ export default class CCDSlicePage {
                 'text-decoration-line': 'line-through',
             },
             cta: {
-                //uncomment once MWPW-168870 is fixed
-                // 'background-color': 'rgb(2, 101, 220)',
-                // color: 'rgb(255, 255, 255)',
+                'background-color': 'rgb(2, 101, 220)',
+                color: 'rgb(255, 255, 255)',
                 'font-size': '12px',
                 'font-weight': '700',
             },

--- a/nala/studio/ccd/slice/specs/slice_discard.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_discard.spec.js
@@ -113,7 +113,7 @@ export default {
         },
         {
             tcid: '9',
-            name: '@studio-slice-discard-change-osi',
+            name: '@studio-slice-discard-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: '3b1fb0f1-b74e-4e8f-81ad-1744012b1935',

--- a/nala/studio/ccd/slice/specs/slice_discard.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_discard.spec.js
@@ -130,5 +130,17 @@ export default {
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-discard',
         },
+        {
+            tcid: '10',
+            name: '@studio-slice-discard-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '8cf16da3-a95d-4186-8a74-e0a2386631a6',
+                variant: 'accent',
+                newVariant: 'primary-outline',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-discard',
+        },
     ],
 };

--- a/nala/studio/ccd/slice/specs/slice_edit.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_edit.spec.js
@@ -7,6 +7,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '8cf16da3-a95d-4186-8a74-e0a2386631a6',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-edit',
@@ -112,6 +113,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '8cf16da3-a95d-4186-8a74-e0a2386631a6',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
                 ctaText: 'Buy now',
                 newCtaText: 'Buy now 2',
             },
@@ -153,6 +155,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '8cf16da3-a95d-4186-8a74-e0a2386631a6',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-edit',
@@ -197,6 +200,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '8cf16da3-a95d-4186-8a74-e0a2386631a6',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
                 variant: 'accent',
                 ctaCSS: {
                     'background-color': 'rgb(2, 101, 220)',

--- a/nala/studio/ccd/slice/specs/slice_edit.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_edit.spec.js
@@ -174,7 +174,7 @@ export default {
         },
         {
             tcid: '13',
-            name: '@studio-slice-change-osi',
+            name: '@studio-slice-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: '3b1fb0f1-b74e-4e8f-81ad-1744012b1935',
@@ -187,6 +187,25 @@ export default {
                 newPlanTypeTag: 'plan_type/puf',
                 newOfferTypeTag: 'offer_type/trial',
                 newMarketSegmentsTag: 'market_segments/edu',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-edit',
+        },
+        {
+            tcid: '14',
+            name: '@studio-slice-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '8cf16da3-a95d-4186-8a74-e0a2386631a6',
+                variant: 'accent',
+                ctaCSS: {
+                    'background-color': 'rgb(2, 101, 220)',
+                    color: 'rgb(255, 255, 255)',
+                },
+                newVariant: 'primary-outline',
+                newCtaCSS: {
+                    color: 'rgb(34, 34, 34)',
+                },
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-edit',

--- a/nala/studio/ccd/slice/specs/slice_save.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_save.spec.js
@@ -26,6 +26,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
@@ -36,6 +37,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
@@ -65,6 +67,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
                 variant: 'accent',
                 ctaCSS: {
                     'background-color': 'rgb(2, 101, 220)',

--- a/nala/studio/ccd/slice/specs/slice_save.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_save.spec.js
@@ -42,7 +42,7 @@ export default {
         },
         {
             tcid: '3',
-            name: '@studio-slice-save-change-osi',
+            name: '@studio-slice-save-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',

--- a/nala/studio/ccd/slice/specs/slice_save.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_save.spec.js
@@ -3,25 +3,6 @@ export default {
     features: [
         {
             tcid: '0',
-            name: '@studio-slice-clone-edit-save-delete',
-            path: '/studio.html',
-            data: {
-                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
-                description: 'Field Edit & Save',
-                newDescription: 'Cloned Field Edit',
-                newBadge: 'New Badge',
-                newIconURL:
-                    'https://www.adobe.com/content/dam/shared/images/product-icons/svg/illustrator.svg',
-                price: 'US$17.24/mo',
-                strikethroughPrice: 'US$34.49/mo',
-                ctaText: 'Buy now',
-                newCtaText: 'Buy now 2',
-            },
-            browserParams: '#query=',
-            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
-        },
-        {
-            tcid: '1',
             name: '@studio-slice-save-variant-change-to-suggested',
             path: '/studio.html',
             data: {
@@ -32,7 +13,7 @@ export default {
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
         },
         {
-            tcid: '2',
+            tcid: '1',
             name: '@studio-slice-save-variant-change-to-trybuywidget',
             path: '/studio.html',
             data: {
@@ -43,7 +24,93 @@ export default {
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
         },
         {
+            tcid: '2',
+            name: '@studio-slice-save-edit-size',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
+        {
             tcid: '3',
+            name: '@studio-slice-save-edit-description',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                description: 'Field Edit & Save',
+                newDescription: 'Cloned Field Edit',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
+        {
+            tcid: '4',
+            name: '@studio-slice-save-edit-badge',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                newBadge: 'New Badge',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
+        {
+            tcid: '5',
+            name: '@studio-slice-save-edit-mnemonic',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                iconURL:
+                    'https://www.adobe.com/content/dam/shared/images/product-icons/svg/photoshop.svg',
+                newIconURL:
+                    'https://www.adobe.com/content/dam/shared/images/product-icons/svg/illustrator.svg',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
+        {
+            tcid: '6',
+            name: '@studio-slice-save-edit-image',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                backgroundURL:
+                    'https://milo.adobe.com/assets/img/commerce/media_10bef5ec21c22fd7fe201cb02735082df13bf4960.jpeg',
+                newBackgroundURL:
+                    'https://milo.adobe.com/assets/img/commerce/media_158c1c22b1322dd28d7912d30fb27f29aa79f79b1.png',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
+        {
+            tcid: '7',
+            name: '@studio-slice-save-edit-price',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                price: 'US$17.24/mo',
+                strikethroughPrice: 'US$34.49/mo',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
+        {
+            tcid: '8',
+            name: '@studio-slice-save-edit-cta',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                ctaText: 'Buy now',
+                newCtaText: 'Buy now 2',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
+
+        {
+            tcid: '9',
             name: '@studio-slice-save-edit-osi',
             path: '/studio.html',
             data: {
@@ -62,7 +129,7 @@ export default {
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
         },
         {
-            tcid: '4',
+            tcid: '10',
             name: '@studio-slice-save-edit-cta-variant',
             path: '/studio.html',
             data: {

--- a/nala/studio/ccd/slice/specs/slice_save.spec.js
+++ b/nala/studio/ccd/slice/specs/slice_save.spec.js
@@ -59,5 +59,24 @@ export default {
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
         },
+        {
+            tcid: '4',
+            name: '@studio-slice-save-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '478f4f3f-0db4-461b-bf89-a7059fb9655c',
+                variant: 'accent',
+                ctaCSS: {
+                    'background-color': 'rgb(2, 101, 220)',
+                    color: 'rgb(255, 255, 255)',
+                },
+                newVariant: 'primary-outline',
+                newCtaCSS: {
+                    color: 'rgb(34, 34, 34)',
+                },
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-slice @ccd-slice-save',
+        },
     ],
 };

--- a/nala/studio/ccd/slice/tests/slice_css.test.js
+++ b/nala/studio/ccd/slice/tests/slice_css.test.js
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import StudioPage from '../../../studio.page.js';
 import CCDSliceSpec from '../specs/slice_css.spec.js';
 import CCDSlicePage from '../slice.page.js';
-import OSTPage from '../../../ost.page.js';
 import WebUtil from '../../../../libs/webutil.js';
 
 const { features } = CCDSliceSpec;
@@ -10,7 +9,6 @@ const miloLibs = process.env.MILO_LIBS || '';
 
 let studio;
 let slice;
-let ost;
 let webUtil;
 
 test.beforeEach(async ({ page, browserName }) => {
@@ -22,7 +20,6 @@ test.beforeEach(async ({ page, browserName }) => {
     }
     studio = new StudioPage(page);
     slice = new CCDSlicePage(page);
-    ost = new OSTPage(page);
     webUtil = new WebUtil(page);
 });
 
@@ -329,7 +326,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
         });
     });
 
-    // @studio-slice-css-cta-cta - Validate CTA CSS for slice cards
+    // @studio-slice-css-cta - Validate CTA CSS for slice cards
     test(`${features[7].name},${features[7].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/slice/tests/slice_discard.test.js
+++ b/nala/studio/ccd/slice/tests/slice_discard.test.js
@@ -699,7 +699,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
     });
 
     // @studio-slice-discard-edit-cta-variant - Validate changing CTA variant for slice card in mas studio
-    test(`${features[10].name},${features[10].tags}`, async ({
+    test.skip(`${features[10].name},${features[10].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ccd/slice/tests/slice_discard.test.js
+++ b/nala/studio/ccd/slice/tests/slice_discard.test.js
@@ -698,7 +698,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
         });
     });
 
-    // @studio-slice-discard-edit-cta-variant - Validate changing cta variant for slice card in mas studio
+    // @studio-slice-discard-edit-cta-variant - Validate changing CTA variant for slice card in mas studio
     test(`${features[10].name},${features[10].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/slice/tests/slice_discard.test.js
+++ b/nala/studio/ccd/slice/tests/slice_discard.test.js
@@ -697,4 +697,69 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             );
         });
     });
+
+    // @studio-slice-discard-edit-cta-variant - Validate changing cta variant for slice card in mas studio
+    test(`${features[10].name},${features[10].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[10];
+        const testPage = `${baseURL}${features[10].path}${miloLibs}${features[10].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'slice-wide'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Edit CTA variant', async () => {
+            await expect(
+                await studio.editorPanel
+                    .locator(studio.editorFooter)
+                    .locator(studio.linkEdit),
+            ).toBeVisible();
+            await expect(await studio.editorCTA).toBeVisible();
+            await expect(await studio.editorCTA).toHaveClass(data.variant);
+            await studio.editorCTA.click();
+            await studio.editorPanel
+                .locator(studio.editorFooter)
+                .locator(studio.linkEdit)
+                .click();
+            await expect(await studio.linkVariant).toBeVisible();
+            await expect(await studio.linkSave).toBeVisible();
+            await expect(
+                await studio.getLinkVariant(data.newVariant),
+            ).toBeVisible();
+            await (await studio.getLinkVariant(data.newVariant)).click();
+            await studio.linkSave.click();
+            await expect(await studio.editorCTA).toHaveClass(data.newVariant);
+        });
+
+        await test.step('step-4: Close the editor and verify discard is triggered', async () => {
+            await studio.editorPanel.locator(studio.closeEditor).click();
+            await expect(
+                await studio.editorPanel.locator(studio.confirmationDialog),
+            ).toBeVisible();
+            await studio.editorPanel.locator(studio.discardDialog).click();
+            await expect(await studio.editorPanel).not.toBeVisible();
+        });
+
+        await test.step('step-4: Open the editor and validate there are no changes', async () => {
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+            await expect(await studio.editorCTA).toBeVisible();
+            await expect(await studio.editorCTA).not.toHaveClass(
+                data.newVariant,
+            );
+            await expect(await studio.editorCTA).toHaveClass(data.variant);
+        });
+    });
 });

--- a/nala/studio/ccd/slice/tests/slice_discard.test.js
+++ b/nala/studio/ccd/slice/tests/slice_discard.test.js
@@ -588,7 +588,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
         });
     });
 
-    // @studio-slice-discard-change-osi - Validate changing OSI for slice card in mas studio
+    // @studio-slice-discard-edit-osi - Validate changing OSI for slice card in mas studio
     test(`${features[9].name},${features[9].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/slice/tests/slice_edit.test.js
+++ b/nala/studio/ccd/slice/tests/slice_edit.test.js
@@ -1102,7 +1102,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
     });
 
     // @studio-slice-edit-cta-variant - Validate edit CTA variant for slice card in mas studio
-    test(`${features[14].name},${features[14].tags}`, async ({
+    test.skip(`${features[14].name},${features[14].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ccd/slice/tests/slice_edit.test.js
+++ b/nala/studio/ccd/slice/tests/slice_edit.test.js
@@ -1103,7 +1103,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(await studio.editorPanel).toBeVisible();
         });
 
-        await test.step('step-3: Edit CTA link', async () => {
+        await test.step('step-3: Edit CTA variant', async () => {
             await expect(
                 await studio.editorPanel
                     .locator(studio.editorFooter)

--- a/nala/studio/ccd/slice/tests/slice_edit.test.js
+++ b/nala/studio/ccd/slice/tests/slice_edit.test.js
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import StudioPage from '../../../studio.page.js';
 import CCDSliceSpec from '../specs/slice_edit.spec.js';
 import CCDSlicePage from '../slice.page.js';
+import CCDSuggestedPage from '../../suggested/suggested.page.js';
 import AHTryBuyWidgetPage from '../../../ahome/try-buy-widget/try-buy-widget.page.js';
 import OSTPage from '../../../ost.page.js';
 import WebUtil from '../../../../libs/webutil.js';
@@ -11,6 +12,7 @@ const miloLibs = process.env.MILO_LIBS || '';
 
 let studio;
 let slice;
+let suggested;
 let ost;
 let trybuywidget;
 let webUtil;
@@ -24,6 +26,7 @@ test.beforeEach(async ({ page, browserName }) => {
     }
     studio = new StudioPage(page);
     slice = new CCDSlicePage(page);
+    suggested = new CCDSuggestedPage(page);
     trybuywidget = new AHTryBuyWidgetPage(page);
     ost = new OSTPage(page);
     webUtil = new WebUtil(page);
@@ -108,6 +111,14 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(
                 await studio.getCard(data.cardid, 'suggested'),
             ).toBeVisible();
+            await expect(await suggested.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(suggested.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -595,6 +606,14 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
 
         await test.step('step-5: Validate edited CTA on the card', async () => {
             await expect(await slice.cardCTA).toContainText(data.newCtaText);
+            await expect(await slice.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await slice.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -800,12 +819,11 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await ost.checkoutLinkUse.click();
         });
 
-        // uncomment once MWPW-169011 is fixed
-        // await test.step('step-7: Validate promo removed in Editor panel', async () => {
-        //     await expect(
-        //         await studio.editorPanel.locator(studio.editorCTA),
-        //     ).not.toHaveAttribute('data-promotion-code');
-        // });
+        await test.step('step-7: Validate promo removed in Editor panel', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorCTA),
+            ).not.toHaveAttribute('data-promotion-code');
+        });
 
         await test.step('step-8: Validate CTA promo removed from the card', async () => {
             await expect(await slice.cardCTA).not.toHaveAttribute(
@@ -860,42 +878,39 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(
                 await studio.editorPanel.locator(studio.editorVariant),
             ).toHaveAttribute('default-value', 'ah-try-buy-widget');
-
-            // *** uncomment once MWPW-164093 (AHome PR) is merged to main ***
-
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorSize),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorTitle),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorSubtitle),
-            // ).not.toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBadge),
-            // ).not.toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorDescription),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorIconURL),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBorderColor),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBackgroundColor),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBackgroundImage),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorPrices),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorFooter),
-            // ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorSize),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorTitle),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorSubtitle),
+            ).not.toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBadge),
+            ).not.toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBorderColor),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundColor),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorPrices),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorFooter),
+            ).toBeVisible();
         });
 
         await test.step('step-5: Validate card variant change', async () => {
@@ -905,14 +920,19 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(
                 await studio.getCard(data.cardid, 'slice-wide'),
             ).not.toBeVisible();
-
-            // *** uncomment once MWPW-164093 (AHome PR) is merged to main ***
-
-            // await expect(await trybuywidget.cardTitle).toBeVisible();
-            // await expect(await trybuywidget.cardDescription).toBeVisible();
-            // await expect(await trybuywidget.cardPrice).toBeVisible();
-            // await expect(await trybuywidget.cardCTA).toBeVisible();
-            // await expect(await trybuywidget.cardIcon).toBeVisible();
+            await expect(await trybuywidget.cardTitle).toBeVisible();
+            await expect(await trybuywidget.cardDescription).toBeVisible();
+            await expect(await trybuywidget.cardPrice).toBeVisible();
+            await expect(await trybuywidget.cardIcon).toBeVisible();
+            await expect(await trybuywidget.cardCTA).toBeVisible();
+            await expect(await trybuywidget.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await trybuywidget.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -1137,6 +1157,14 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             expect(
                 await webUtil.verifyCSS(await slice.cardCTA, data.newCtaCSS),
             ).toBeTruthy();
+            await expect(await slice.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await slice.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 });

--- a/nala/studio/ccd/slice/tests/slice_edit.test.js
+++ b/nala/studio/ccd/slice/tests/slice_edit.test.js
@@ -1128,7 +1128,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await studio.linkSave.click();
         });
 
-        await test.step('step-4: Validate edited CTA Link in Editor panel', async () => {
+        await test.step('step-4: Validate edited CTA variant in Editor panel', async () => {
             await expect(await studio.editorCTA).toHaveClass(data.newVariant);
             await expect(await studio.editorCTA).not.toHaveClass(data.variant);
         });

--- a/nala/studio/ccd/slice/tests/slice_save.test.js
+++ b/nala/studio/ccd/slice/tests/slice_save.test.js
@@ -755,7 +755,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
     });
 
     // @studio-slice-save-edit-cta-variant - Validate saving change CTA variant
-    test(`${features[10].name},${features[10].tags}`, async ({
+    test.skip(`${features[10].name},${features[10].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ccd/slice/tests/slice_save.test.js
+++ b/nala/studio/ccd/slice/tests/slice_save.test.js
@@ -404,7 +404,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
         });
     });
 
-    // @studio-slice-save-edit-cta-variant - Validate saving change cta variant
+    // @studio-slice-save-edit-cta-variant - Validate saving change CTA variant
     test(`${features[4].name},${features[4].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/slice/tests/slice_save.test.js
+++ b/nala/studio/ccd/slice/tests/slice_save.test.js
@@ -55,7 +55,7 @@ test.afterEach(async ({ page }) => {
 });
 
 test.describe('M@S Studio CCD Slice card test suite', () => {
-    // @studio-slice-clone-edit-save-delete - Clone Field & Edit card, edit, save then delete slice card
+    // @studio-slice-save-variant-change-to-suggested - Validate saving card after variant change to ccd suggested
     test(`${features[0].name},${features[0].tags}`, async ({
         page,
         baseURL,
@@ -93,100 +93,47 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await page.waitForTimeout(2000);
         });
 
-        await test.step('step-4: Edit fields and save card', async () => {
+        await test.step('step-4: Change variant and save card', async () => {
             await expect(
-                await studio.editorPanel.locator(studio.editorDescription),
+                await studio.editorPanel.locator(studio.editorVariant),
             ).toBeVisible();
             await expect(
-                await studio.editorPanel.locator(studio.editorDescription),
-            ).toContainText(data.description);
-            // edit price
-            await (
-                await studio.editorPanel
-                    .locator(studio.editorDescription)
-                    .locator(studio.regularPrice)
-            ).dblclick();
-            await expect(await ost.price).toBeVisible();
-            await expect(await ost.priceUse).toBeVisible();
-            await expect(await ost.oldPriceCheckbox).toBeVisible();
-            await ost.oldPriceCheckbox.click();
-            await ost.priceUse.click();
-            // edit CTA
-            await studio.editorCTA.click();
+                await studio.editorPanel.locator(studio.editorVariant),
+            ).toHaveAttribute('default-value', 'ccd-slice');
             await studio.editorPanel
-                .locator(studio.editorFooter)
-                .locator(studio.linkEdit)
+                .locator(studio.editorVariant)
+                .locator('sp-picker')
+                .first()
                 .click();
-            await expect(await studio.linkText).toBeVisible();
-            await expect(await studio.linkSave).toBeVisible();
-            await expect(await studio.linkText).toHaveValue(data.ctaText);
-            await studio.linkText.fill(data.newCtaText);
-            await studio.linkSave.click();
-            // edit badge
-            await studio.editorPanel
-                .locator(studio.editorBadge)
-                .fill(data.newBadge);
-            // edit size
-            await studio.editorPanel.locator(studio.editorSize).click();
-            await page.getByRole('option', { name: 'default' }).click();
-            await studio.editorPanel
-                .locator(studio.editorIconURL)
-                .fill(data.newIconURL);
-            //save card
+            await page.getByRole('option', { name: 'suggested' }).click();
+            await page.waitForTimeout(2000);
             await studio.saveCard();
         });
 
-        await test.step('step-5: Validate edited fields in Editor panel', async () => {
+        await test.step('step-5: Validate variant change', async () => {
             await expect(
-                await studio.editorPanel.locator(studio.editorBadge),
-            ).toHaveValue(data.newBadge);
-            await expect(
-                await studio.editorPanel.locator(studio.editorIconURL),
-            ).toHaveValue(data.newIconURL);
-            await expect(
-                await studio.editorPanel.locator(studio.editorDescription),
-            ).toContainText(data.price);
-            await expect(
-                await studio.editorPanel.locator(studio.editorDescription),
-            ).not.toContainText(data.strikethroughPrice);
-            await expect(
-                await studio.editorPanel.locator(studio.editorFooter),
-            ).toContainText(data.newCtaText);
-        });
-
-        await test.step('step-6: Search for the cloned card and verify changes then delete the card', async () => {
-            const clonedCard = await studio.getCard(data.clonedCardID, 'slice');
-            await expect(
-                await studio.getCard(data.clonedCardID, 'slice'),
-            ).toBeVisible();
+                await studio.editorPanel.locator(studio.editorVariant),
+            ).toHaveAttribute('default-value', 'ccd-suggested');
             await expect(
                 await studio.getCard(data.clonedCardID, 'slice-wide'),
             ).not.toBeVisible();
-            await expect(await clonedCard.locator(slice.cardBadge)).toHaveText(
-                data.newBadge,
-            );
             await expect(
-                await clonedCard.locator(slice.cardIcon),
-            ).toHaveAttribute('src', data.newIconURL);
+                await studio.getCard(data.clonedCardID, 'suggested'),
+            ).toBeVisible();
             await expect(
-                await clonedCard.locator(slice.cardDescription),
-            ).toContainText(data.price);
+                await (
+                    await studio.getCard(data.clonedCardID, 'suggested')
+                ).locator(suggested.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
             await expect(
-                await clonedCard.locator(slice.cardDescription),
-            ).not.toContainText(data.strikethroughPrice);
-            await expect(await clonedCard.locator(slice.cardCTA)).toContainText(
-                data.newCtaText,
-            );
-
-            //delete the card
-            await studio.deleteCard();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'slice'),
-            ).not.toBeVisible();
+                await (
+                    await studio.getCard(data.clonedCardID, 'suggested')
+                ).locator(suggested.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
-    // @studio-slice-save-variant-change-to-suggested - Validate saving card after variant change to ccd suggested
+    // @studio-slice-save-variant-change-to-trybuywidget - Validate saving card after variant change to AHome try-buy-widget
     test(`${features[1].name},${features[1].tags}`, async ({
         page,
         baseURL,
@@ -236,36 +183,35 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
                 .locator('sp-picker')
                 .first()
                 .click();
-            await page.getByRole('option', { name: 'suggested' }).click();
+            await page.getByRole('option', { name: 'try buy widget' }).click();
             await page.waitForTimeout(2000);
-            // save card
             await studio.saveCard();
         });
 
         await test.step('step-5: Validate variant change', async () => {
             await expect(
                 await studio.editorPanel.locator(studio.editorVariant),
-            ).toHaveAttribute('default-value', 'ccd-suggested');
+            ).toHaveAttribute('default-value', 'ah-try-buy-widget');
             await expect(
                 await studio.getCard(data.clonedCardID, 'slice-wide'),
             ).not.toBeVisible();
             await expect(
-                await studio.getCard(data.clonedCardID, 'suggested'),
+                await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
             ).toBeVisible();
             await expect(
                 await (
-                    await studio.getCard(data.clonedCardID, 'suggested')
-                ).locator(suggested.cardCTA),
+                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
+                ).locator(trybuywidget.cardCTA),
             ).toHaveAttribute('data-wcs-osi', data.osi);
             await expect(
                 await (
-                    await studio.getCard(data.clonedCardID, 'suggested')
-                ).locator(suggested.cardCTA),
+                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
+                ).locator(trybuywidget.cardCTA),
             ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
-    // @studio-slice-save-variant-change-to-trybuywidget - Validate saving card after variant change to AHome try-buy-widget
+    // @studio-slice-save-edit-size - Validate saving card after editing card size
     test(`${features[2].name},${features[2].tags}`, async ({
         page,
         baseURL,
@@ -303,54 +249,433 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await page.waitForTimeout(2000);
         });
 
-        await test.step('step-4: Change variant and save card', async () => {
+        await test.step('step-4: Edit size and save card', async () => {
             await expect(
-                await studio.editorPanel.locator(studio.editorVariant),
+                await studio.editorPanel.locator(studio.editorSize),
             ).toBeVisible();
-            await expect(
-                await studio.editorPanel.locator(studio.editorVariant),
-            ).toHaveAttribute('default-value', 'ccd-slice');
-            await studio.editorPanel
-                .locator(studio.editorVariant)
-                .locator('sp-picker')
-                .first()
-                .click();
-            await page.getByRole('option', { name: 'try buy widget' }).click();
-            await page.waitForTimeout(2000);
-            // save card
+            await studio.editorPanel.locator(studio.editorSize).click();
+            await page.getByRole('option', { name: 'default' }).click();
             await studio.saveCard();
         });
 
-        await test.step('step-5: Validate variant change', async () => {
+        await test.step('step-5: Validate edited card size', async () => {
             await expect(
-                await studio.editorPanel.locator(studio.editorVariant),
-            ).toHaveAttribute('default-value', 'ah-try-buy-widget');
-            await expect(
-                await studio.getCard(data.clonedCardID, 'slice-wide'),
-            ).not.toBeVisible();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
-            ).toBeVisible();
-            await expect(
-                await (
-                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
-                ).locator(trybuywidget.cardCTA),
-            ).toHaveAttribute('data-wcs-osi', data.osi);
-            await expect(
-                await (
-                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
-                ).locator(trybuywidget.cardCTA),
-            ).toHaveAttribute('is', 'checkout-button');
+                await studio.getCard(data.clonedCardID, 'slice'),
+            ).not.toHaveAttribute('size', 'wide');
         });
     });
 
-    // @studio-slice-save-edit-osi - Validate saving change osi
+    // @studio-slice-save-edit-description - Validate saving card after editing card description
     test(`${features[3].name},${features[3].tags}`, async ({
         page,
         baseURL,
     }) => {
         const { data } = features[3];
         const testPage = `${baseURL}${features[3].path}${miloLibs}${features[3].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'slice-wide'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'slice-wide',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit description and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toContainText(data.description);
+            await studio.editorPanel
+                .locator(studio.editorDescription)
+                .fill(data.newDescription);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card description', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toContainText(data.newDescription);
+            await expect(
+                await clonedCard.locator(slice.cardDescription),
+            ).toHaveText(data.newDescription);
+        });
+    });
+
+    // @studio-slice-save-edit-badge - Validate saving card after editing card badge
+    test(`${features[4].name},${features[4].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[4];
+        const testPage = `${baseURL}${features[4].path}${miloLibs}${features[4].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'slice-wide'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'slice-wide',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit fields and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorBadge),
+            ).toBeVisible();
+            await studio.editorPanel
+                .locator(studio.editorBadge)
+                .fill(data.newBadge);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card badge', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorBadge),
+            ).toHaveValue(data.newBadge);
+            await expect(
+                await clonedCard.locator(slice.cardBadge),
+            ).toBeVisible();
+            await expect(await clonedCard.locator(slice.cardBadge)).toHaveText(
+                data.newBadge,
+            );
+        });
+    });
+
+    // @studio-slice-save-edit-mnemonic - Validate saving card after editing card mnemonic
+    test(`${features[5].name},${features[5].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[5];
+        const testPage = `${baseURL}${features[5].path}${miloLibs}${features[5].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'slice-wide'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'slice-wide',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit mnemonic and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toHaveValue(data.iconURL);
+            await studio.editorPanel
+                .locator(studio.editorIconURL)
+                .fill(data.newIconURL);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card mnemonic', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toHaveValue(data.newIconURL);
+            await expect(
+                await clonedCard.locator(slice.cardIcon),
+            ).toHaveAttribute('src', data.newIconURL);
+        });
+    });
+
+    // @studio-slice-save-edit-image - Validate saving card after editing card image
+    test(`${features[6].name},${features[6].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[6];
+        const testPage = `${baseURL}${features[6].path}${miloLibs}${features[6].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'slice-wide'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'slice-wide',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit background image and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toHaveValue(data.backgroundURL);
+            await studio.editorPanel
+                .locator(studio.editorBackgroundImage)
+                .fill(data.newBackgroundURL);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card image', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toHaveValue(data.newBackgroundURL);
+            await expect(
+                await clonedCard.locator(slice.cardImage),
+            ).toBeVisible();
+            await expect(
+                await clonedCard.locator(slice.cardImage),
+            ).toHaveAttribute('src', data.newBackgroundURL);
+        });
+    });
+
+    // @studio-slice-save-edit-price - Validate saving card after editing card price
+    test(`${features[7].name},${features[7].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[7];
+        const testPage = `${baseURL}${features[7].path}${miloLibs}${features[7].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'slice-wide'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'slice-wide',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit price and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toBeVisible();
+            await expect(
+                await clonedCard.locator(slice.cardDescription),
+            ).toContainText(data.strikethroughPrice);
+            await (
+                await studio.editorPanel
+                    .locator(studio.editorDescription)
+                    .locator(studio.regularPrice)
+            ).dblclick();
+            await expect(await ost.price).toBeVisible();
+            await expect(await ost.priceUse).toBeVisible();
+            await expect(await ost.oldPriceCheckbox).toBeVisible();
+            await ost.oldPriceCheckbox.click();
+            await ost.priceUse.click();
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited fields in Editor panel', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toContainText(data.price);
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).not.toContainText(data.strikethroughPrice);
+            await expect(
+                await clonedCard.locator(slice.cardDescription),
+            ).toContainText(data.price);
+            await expect(
+                await clonedCard.locator(slice.cardDescription),
+            ).not.toContainText(data.strikethroughPrice);
+        });
+    });
+
+    // @studio-slice-save-edit-cta - Validate saving card after editing card cta
+    test(`${features[8].name},${features[8].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[8];
+        const testPage = `${baseURL}${features[8].path}${miloLibs}${features[8].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'slice-wide'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'slice-wide')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'slice-wide',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit cta and save card', async () => {
+            await expect(
+                await studio.editorPanel
+                    .locator(studio.editorFooter)
+                    .locator(studio.linkEdit),
+            ).toBeVisible();
+            await expect(await studio.editorCTA).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorFooter),
+            ).toContainText(data.ctaText);
+            await studio.editorCTA.click();
+            await studio.editorPanel
+                .locator(studio.editorFooter)
+                .locator(studio.linkEdit)
+                .click();
+            await expect(await studio.linkText).toBeVisible();
+            await expect(await studio.linkSave).toBeVisible();
+            await expect(await studio.linkText).toHaveValue(data.ctaText);
+            await studio.linkText.fill(data.newCtaText);
+            await studio.linkSave.click();
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card cta', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorFooter),
+            ).toContainText(data.newCtaText);
+            await expect(await clonedCard.locator(slice.cardCTA)).toContainText(
+                data.newCtaText,
+            );
+            await expect(
+                await clonedCard.locator(slice.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await clonedCard.locator(slice.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
+        });
+    });
+
+    // @studio-slice-save-edit-osi - Validate saving change osi
+    test(`${features[9].name},${features[9].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[9];
+        const testPage = `${baseURL}${features[9].path}${miloLibs}${features[9].browserParams}${data.cardid}`;
         console.info('[Test Page]: ', testPage);
 
         await test.step('step-1: Go to MAS Studio test page', async () => {
@@ -393,7 +718,6 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await (await ost.nextButton).click();
             await expect(await ost.priceUse).toBeVisible();
             await ost.priceUse.click();
-            // save card
             await studio.saveCard();
         });
 
@@ -431,12 +755,12 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
     });
 
     // @studio-slice-save-edit-cta-variant - Validate saving change CTA variant
-    test(`${features[4].name},${features[4].tags}`, async ({
+    test(`${features[10].name},${features[10].tags}`, async ({
         page,
         baseURL,
     }) => {
-        const { data } = features[4];
-        const testPage = `${baseURL}${features[4].path}${miloLibs}${features[4].browserParams}${data.cardid}`;
+        const { data } = features[10];
+        const testPage = `${baseURL}${features[10].path}${miloLibs}${features[10].browserParams}${data.cardid}`;
         console.info('[Test Page]: ', testPage);
         let clonedCard;
 
@@ -495,7 +819,6 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             ).toBeVisible();
             await (await studio.getLinkVariant(data.newVariant)).click();
             await studio.linkSave.click();
-            // save card
             await studio.saveCard();
         });
 

--- a/nala/studio/ccd/slice/tests/slice_save.test.js
+++ b/nala/studio/ccd/slice/tests/slice_save.test.js
@@ -252,14 +252,16 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'suggested'),
             ).toBeVisible();
-            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA)).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA)).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'suggested')
+                ).locator(suggested.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'suggested')
+                ).locator(suggested.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
@@ -329,14 +331,16 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
             ).toBeVisible();
-            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
+                ).locator(trybuywidget.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
+                ).locator(trybuywidget.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
@@ -504,14 +508,12 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
-            await expect(await clonedCard.locator(slice.cardCTA)).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await clonedCard.locator(slice.cardCTA)).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await clonedCard.locator(slice.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await clonedCard.locator(slice.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 });

--- a/nala/studio/ccd/slice/tests/slice_save.test.js
+++ b/nala/studio/ccd/slice/tests/slice_save.test.js
@@ -41,7 +41,7 @@ test.afterEach(async ({ page }) => {
         await studio.deleteCard();
         await expect(cardToClean).not.toBeVisible();
     }
-    
+
     await page.close();
 });
 
@@ -315,7 +315,7 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
         });
     });
 
-    // @studio-slice-save-change-osi - Validate saving change osi
+    // @studio-slice-save-edit-osi - Validate saving change osi
     test(`${features[3].name},${features[3].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/slice/tests/slice_save.test.js
+++ b/nala/studio/ccd/slice/tests/slice_save.test.js
@@ -2,6 +2,8 @@ import { expect, test } from '@playwright/test';
 import StudioPage from '../../../studio.page.js';
 import CCDSliceSpec from '../specs/slice_save.spec.js';
 import CCDSlicePage from '../slice.page.js';
+import CCDSuggestedPage from '../../suggested/suggested.page.js';
+import AHTryBuyWidgetPage from '../../../ahome/try-buy-widget/try-buy-widget.page.js';
 import OSTPage from '../../../ost.page.js';
 import WebUtil from '../../../../libs/webutil.js';
 
@@ -10,6 +12,8 @@ const miloLibs = process.env.MILO_LIBS || '';
 
 let studio;
 let slice;
+let suggested;
+let trybuywidget;
 let ost;
 let clonedCardID;
 let webUtil;
@@ -23,6 +27,8 @@ test.beforeEach(async ({ page, browserName }) => {
     }
     studio = new StudioPage(page);
     slice = new CCDSlicePage(page);
+    suggested = new CCDSuggestedPage(page);
+    trybuywidget = new AHTryBuyWidgetPage(page);
     ost = new OSTPage(page);
     clonedCardID = '';
     webUtil = new WebUtil(page);
@@ -246,6 +252,14 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'suggested'),
             ).toBeVisible();
+            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA)).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await (await studio.getCard(data.clonedCardID, 'suggested')).locator(suggested.cardCTA)).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -315,6 +329,14 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
             ).toBeVisible();
+            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -482,6 +504,14 @@ test.describe('M@S Studio CCD Slice card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
+            await expect(await clonedCard.locator(slice.cardCTA)).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await clonedCard.locator(slice.cardCTA)).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 });

--- a/nala/studio/ccd/suggested/specs/suggested_discard.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_discard.spec.js
@@ -113,7 +113,7 @@ export default {
         },
         {
             tcid: '9',
-            name: '@studio-suggested-discard-change-osi',
+            name: '@studio-suggested-discard-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',

--- a/nala/studio/ccd/suggested/specs/suggested_discard.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_discard.spec.js
@@ -130,5 +130,17 @@ export default {
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-discard',
         },
+        {
+            tcid: '10',
+            name: '@studio-suggested-discard-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '206a8742-0289-4196-92d4-ced99ec4191e',
+                variant: 'primary-outline',
+                newVariant: 'accent',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-discard',
+        },
     ],
 };

--- a/nala/studio/ccd/suggested/specs/suggested_edit.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_edit.spec.js
@@ -174,7 +174,7 @@ export default {
         },
         {
             tcid: '13',
-            name: '@studio-suggested-change-osi',
+            name: '@studio-suggested-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
@@ -187,6 +187,25 @@ export default {
                 newPlanTypeTag: 'plan_type/puf',
                 newOfferTypeTag: 'offer_type/trial',
                 newMarketSegmentsTag: 'market_segments/edu',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-edit',
+        },
+        {
+            tcid: '14',
+            name: '@studio-suggested-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: '206a8742-0289-4196-92d4-ced99ec4191e',
+                variant: 'primary-outline',
+                ctaCSS: {
+                    color: 'rgb(34, 34, 34)',
+                },
+                newVariant: 'accent',
+                newCtaCSS: {
+                    'background-color': 'rgb(2, 101, 220)',
+                    color: 'rgb(255, 255, 255)',
+                },
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-edit',

--- a/nala/studio/ccd/suggested/specs/suggested_edit.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_edit.spec.js
@@ -7,6 +7,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '206a8742-0289-4196-92d4-ced99ec4191e',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-edit',
@@ -112,6 +113,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '206a8742-0289-4196-92d4-ced99ec4191e',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
                 ctaText: 'Buy now',
                 newCtaText: 'Buy now 2',
             },
@@ -153,6 +155,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '206a8742-0289-4196-92d4-ced99ec4191e',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-edit',
@@ -197,6 +200,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: '206a8742-0289-4196-92d4-ced99ec4191e',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
                 variant: 'primary-outline',
                 ctaCSS: {
                     color: 'rgb(34, 34, 34)',

--- a/nala/studio/ccd/suggested/specs/suggested_save.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_save.spec.js
@@ -37,6 +37,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
@@ -47,6 +48,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
             },
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
@@ -76,6 +78,7 @@ export default {
             path: '/studio.html',
             data: {
                 cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                osi: 'A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M',
                 variant: 'primary-outline',
                 ctaCSS: {
                     color: 'rgb(34, 34, 34)',

--- a/nala/studio/ccd/suggested/specs/suggested_save.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_save.spec.js
@@ -3,26 +3,6 @@ export default {
     features: [
         {
             tcid: '0',
-            name: '@studio-suggested-clone-edit-save-delete',
-            path: '/studio.html',
-            data: {
-                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
-                title: 'Field Edit & Save',
-                newTitle: 'Cloned Field Edit',
-                newSubtitle: 'New Subtitle',
-                newIconURL:
-                    'https://www.adobe.com/content/dam/shared/images/product-icons/svg/illustrator.svg',
-                newDescription: 'New Test Description',
-                price: 'US$17.24/mo',
-                strikethroughPrice: 'US$34.49/mo',
-                ctaText: 'Buy now',
-                newCtaText: 'Buy now 2',
-            },
-            browserParams: '#query=',
-            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
-        },
-        {
-            tcid: '1',
             name: '@studio-suggested-remove-correct-fragment',
             path: '/studio.html',
             data: {
@@ -32,7 +12,7 @@ export default {
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
         },
         {
-            tcid: '2',
+            tcid: '1',
             name: '@studio-suggested-save-variant-change-to-slice',
             path: '/studio.html',
             data: {
@@ -43,7 +23,7 @@ export default {
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
         },
         {
-            tcid: '3',
+            tcid: '2',
             name: '@studio-suggested-save-variant-change-to-trybuywidget',
             path: '/studio.html',
             data: {
@@ -54,7 +34,93 @@ export default {
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
         },
         {
+            tcid: '3',
+            name: '@studio-suggested-save-edit-title',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                title: 'Field Edit & Save',
+                newTitle: 'Cloned Field Edit',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
+        {
             tcid: '4',
+            name: '@studio-suggested-save-edit-eyebrow',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                subtitle: 'do not edit',
+                newSubtitle: 'New Subtitle',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
+        {
+            tcid: '5',
+            name: '@studio-suggested-save-edit-mnemonic',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                iconURL:
+                    'https://www.adobe.com/content/dam/shared/images/product-icons/svg/photoshop.svg',
+                newIconURL:
+                    'https://www.adobe.com/content/dam/shared/images/product-icons/svg/illustrator.svg',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
+        {
+            tcid: '6',
+            name: '@studio-suggested-save-edit-description',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                description: 'MAS repo validation card for Nala tests',
+                newDescription: 'New Test Description',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
+        {
+            tcid: '7',
+            name: '@studio-suggested-save-edit-image',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                newBackgroundURL:
+                    'https://main--milo--adobecom.aem.page/assets/img/commerce/media_1d63dab9ee1edbf371d6f0548516c9e12b3ea3ff4.png',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
+        {
+            tcid: '8',
+            name: '@studio-suggested-save-edit-price',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                price: 'US$17.24/mo',
+                strikethroughPrice: 'US$34.49/mo',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
+        {
+            tcid: '9',
+            name: '@studio-suggested-save-edit-cta',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                ctaText: 'Buy now',
+                newCtaText: 'Buy now 2',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
+        {
+            tcid: '10',
             name: '@studio-suggested-save-edit-osi',
             path: '/studio.html',
             data: {
@@ -73,7 +139,7 @@ export default {
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
         },
         {
-            tcid: '5',
+            tcid: '11',
             name: '@studio-suggested-save-edit-cta-variant',
             path: '/studio.html',
             data: {

--- a/nala/studio/ccd/suggested/specs/suggested_save.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_save.spec.js
@@ -70,5 +70,24 @@ export default {
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
         },
+        {
+            tcid: '5',
+            name: '@studio-suggested-save-edit-cta-variant',
+            path: '/studio.html',
+            data: {
+                cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',
+                variant: 'primary-outline',
+                ctaCSS: {
+                    color: 'rgb(34, 34, 34)',
+                },
+                newVariant: 'accent',
+                newCtaCSS: {
+                    'background-color': 'rgb(2, 101, 220)',
+                    color: 'rgb(255, 255, 255)',
+                },
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested @ccd-suggested-save',
+        },
     ],
 };

--- a/nala/studio/ccd/suggested/specs/suggested_save.spec.js
+++ b/nala/studio/ccd/suggested/specs/suggested_save.spec.js
@@ -53,7 +53,7 @@ export default {
         },
         {
             tcid: '4',
-            name: '@studio-suggested-save-change-osi',
+            name: '@studio-suggested-save-edit-osi',
             path: '/studio.html',
             data: {
                 cardid: 'cc85b026-240a-4280-ab41-7618e65daac4',

--- a/nala/studio/ccd/suggested/suggested.page.js
+++ b/nala/studio/ccd/suggested/suggested.page.js
@@ -10,9 +10,6 @@ export default class CCDSuggestedPage {
         this.cardLegalLink = page.locator('div[slot="body-xs"] p > a');
         this.cardPrice = page.locator('p[slot="price"]');
         this.cardCTA = page.locator('div[slot="cta"] > button');
-        this.cardCTALink = page.locator(
-            'div[slot="cta"] a[is="checkout-link"]',
-        );
 
         // Suggested card properties:
         this.cssProp = {

--- a/nala/studio/ccd/suggested/tests/suggested_css.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_css.test.js
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import StudioPage from '../../../studio.page.js';
 import CCDSuggestedSpec from '../specs/suggested_css.spec.js';
 import CCDSuggestedPage from '../suggested.page.js';
-import OSTPage from '../../../ost.page.js';
 import WebUtil from '../../../../libs/webutil.js';
 
 const { features } = CCDSuggestedSpec;
@@ -10,7 +9,6 @@ const miloLibs = process.env.MILO_LIBS || '';
 
 let studio;
 let suggested;
-let ost;
 let webUtil;
 
 test.beforeEach(async ({ page, browserName }) => {
@@ -22,7 +20,6 @@ test.beforeEach(async ({ page, browserName }) => {
     }
     studio = new StudioPage(page);
     suggested = new CCDSuggestedPage(page);
-    ost = new OSTPage(page);
     webUtil = new WebUtil(page);
 });
 
@@ -208,7 +205,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
         });
     });
 
-    // @studio-suggested-css-cta-cta - Validate CTA CSS for suggested cards
+    // @studio-suggested-css-cta - Validate CTA CSS for suggested cards
     test(`${features[7].name},${features[7].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/suggested/tests/suggested_discard.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_discard.test.js
@@ -700,7 +700,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
     });
 
     // @studio-suggested-discard-edit-cta-variant - Validate changing CTA variant for suggested card in mas studio
-    test(`${features[10].name},${features[10].tags}`, async ({
+    test.skip(`${features[10].name},${features[10].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ccd/suggested/tests/suggested_discard.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_discard.test.js
@@ -698,4 +698,69 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             );
         });
     });
+
+    // @studio-suggested-discard-edit-cta-variant - Validate changing cta variant for suggested card in mas studio
+    test(`${features[10].name},${features[10].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[10];
+        const testPage = `${baseURL}${features[10].path}${miloLibs}${features[10].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Edit CTA variant', async () => {
+            await expect(
+                await studio.editorPanel
+                    .locator(studio.editorFooter)
+                    .locator(studio.linkEdit),
+            ).toBeVisible();
+            await expect(await studio.editorCTA).toBeVisible();
+            await expect(await studio.editorCTA).toHaveClass(data.variant);
+            await studio.editorCTA.click();
+            await studio.editorPanel
+                .locator(studio.editorFooter)
+                .locator(studio.linkEdit)
+                .click();
+            await expect(await studio.linkVariant).toBeVisible();
+            await expect(await studio.linkSave).toBeVisible();
+            await expect(
+                await studio.getLinkVariant(data.newVariant),
+            ).toBeVisible();
+            await (await studio.getLinkVariant(data.newVariant)).click();
+            await studio.linkSave.click();
+            await expect(await studio.editorCTA).toHaveClass(data.newVariant);
+        });
+
+        await test.step('step-4: Close the editor and verify discard is triggered', async () => {
+            await studio.editorPanel.locator(studio.closeEditor).click();
+            await expect(
+                await studio.editorPanel.locator(studio.confirmationDialog),
+            ).toBeVisible();
+            await studio.editorPanel.locator(studio.discardDialog).click();
+            await expect(await studio.editorPanel).not.toBeVisible();
+        });
+
+        await test.step('step-4: Open the editor and validate there are no changes', async () => {
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+            await expect(await studio.editorCTA).toBeVisible();
+            await expect(await studio.editorCTA).not.toHaveClass(
+                data.newVariant,
+            );
+            await expect(await studio.editorCTA).toHaveClass(data.variant);
+        });
+    });
 });

--- a/nala/studio/ccd/suggested/tests/suggested_discard.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_discard.test.js
@@ -589,7 +589,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
         });
     });
 
-    // @studio-suggested-discard-change-osi - Validate changing OSI for suggested card in mas studio
+    // @studio-suggested-discard-edit-osi - Validate changing OSI for suggested card in mas studio
     test(`${features[9].name},${features[9].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/suggested/tests/suggested_discard.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_discard.test.js
@@ -699,7 +699,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
         });
     });
 
-    // @studio-suggested-discard-edit-cta-variant - Validate changing cta variant for suggested card in mas studio
+    // @studio-suggested-discard-edit-cta-variant - Validate changing CTA variant for suggested card in mas studio
     test(`${features[10].name},${features[10].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/suggested/tests/suggested_edit.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_edit.test.js
@@ -4,6 +4,7 @@ import CCDSuggestedSpec from '../specs/suggested_edit.spec.js';
 import CCDSuggestedPage from '../suggested.page.js';
 import AHTryBuyWidgetPage from '../../../ahome/try-buy-widget/try-buy-widget.page.js';
 import OSTPage from '../../../ost.page.js';
+import WebUtil from '../../../../libs/webutil.js';
 
 const { features } = CCDSuggestedSpec;
 const miloLibs = process.env.MILO_LIBS || '';
@@ -12,6 +13,7 @@ let studio;
 let suggested;
 let ost;
 let trybuywidget;
+let webUtil;
 
 test.beforeEach(async ({ page, browserName }) => {
     test.slow();
@@ -24,6 +26,7 @@ test.beforeEach(async ({ page, browserName }) => {
     suggested = new CCDSuggestedPage(page);
     trybuywidget = new AHTryBuyWidgetPage(page);
     ost = new OSTPage(page);
+    webUtil = new WebUtil(page);
 });
 
 test.describe('M@S Studio CCD Suggested card test suite', () => {
@@ -945,7 +948,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
         });
     });
 
-    // @studio-suggested-change-osi - Validate changing OSI for suggested card in mas studio
+    // @studio-suggested-edit-osi - Validate changing OSI for suggested card in mas studio
     test(`${features[13].name},${features[13].tags}`, async ({
         page,
         baseURL,
@@ -1030,6 +1033,68 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
                 'value',
                 new RegExp(`${data.marketSegmentsTag}`),
             );
+        });
+    });
+
+    // @studio-suggested-edit-cta-variant - Validate edit CTA variant for suggested card in mas studio
+    test(`${features[14].name},${features[14].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[14];
+        const testPage = `${baseURL}${features[14].path}${miloLibs}${features[14].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Edit CTA link', async () => {
+            await expect(
+                await studio.editorPanel
+                    .locator(studio.editorFooter)
+                    .locator(studio.linkEdit),
+            ).toBeVisible();
+            await expect(await studio.editorCTA).toBeVisible();
+            await expect(await studio.editorCTA).toHaveClass(data.variant);
+            expect(
+                await webUtil.verifyCSS(await suggested.cardCTA, data.ctaCSS),
+            ).toBeTruthy();
+            await studio.editorCTA.click();
+            await studio.editorPanel
+                .locator(studio.editorFooter)
+                .locator(studio.linkEdit)
+                .click();
+            await expect(await studio.linkVariant).toBeVisible();
+            await expect(await studio.linkSave).toBeVisible();
+            await expect(
+                await studio.getLinkVariant(data.newVariant),
+            ).toBeVisible();
+            await (await studio.getLinkVariant(data.newVariant)).click();
+            await studio.linkSave.click();
+        });
+
+        await test.step('step-4: Validate edited CTA Link in Editor panel', async () => {
+            await expect(await studio.editorCTA).toHaveClass(data.newVariant);
+            await expect(await studio.editorCTA).not.toHaveClass(data.variant);
+        });
+
+        await test.step('step-5: Validate edited CTA on the card', async () => {
+            expect(
+                await webUtil.verifyCSS(
+                    await suggested.cardCTA,
+                    data.newCtaCSS,
+                ),
+            ).toBeTruthy();
         });
     });
 });

--- a/nala/studio/ccd/suggested/tests/suggested_edit.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_edit.test.js
@@ -1083,7 +1083,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await studio.linkSave.click();
         });
 
-        await test.step('step-4: Validate edited CTA Link in Editor panel', async () => {
+        await test.step('step-4: Validate edited CTA variant in Editor panel', async () => {
             await expect(await studio.editorCTA).toHaveClass(data.newVariant);
             await expect(await studio.editorCTA).not.toHaveClass(data.variant);
         });

--- a/nala/studio/ccd/suggested/tests/suggested_edit.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_edit.test.js
@@ -1058,7 +1058,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await expect(await studio.editorPanel).toBeVisible();
         });
 
-        await test.step('step-3: Edit CTA link', async () => {
+        await test.step('step-3: Edit CTA variant', async () => {
             await expect(
                 await studio.editorPanel
                     .locator(studio.editorFooter)

--- a/nala/studio/ccd/suggested/tests/suggested_edit.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_edit.test.js
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import StudioPage from '../../../studio.page.js';
 import CCDSuggestedSpec from '../specs/suggested_edit.spec.js';
 import CCDSuggestedPage from '../suggested.page.js';
+import CCDSlicePage from '../../slice/slice.page.js';
 import AHTryBuyWidgetPage from '../../../ahome/try-buy-widget/try-buy-widget.page.js';
 import OSTPage from '../../../ost.page.js';
 import WebUtil from '../../../../libs/webutil.js';
@@ -11,6 +12,7 @@ const miloLibs = process.env.MILO_LIBS || '';
 
 let studio;
 let suggested;
+let slice;
 let ost;
 let trybuywidget;
 let webUtil;
@@ -24,6 +26,7 @@ test.beforeEach(async ({ page, browserName }) => {
     }
     studio = new StudioPage(page);
     suggested = new CCDSuggestedPage(page);
+    slice = new CCDSlicePage(page);
     trybuywidget = new AHTryBuyWidgetPage(page);
     ost = new OSTPage(page);
     webUtil = new WebUtil(page);
@@ -110,6 +113,14 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             ).not.toBeVisible();
             await expect(await suggested.cardTitle).not.toBeVisible();
             await expect(await suggested.cardEyebrow).not.toBeVisible();
+            await expect(await slice.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await slice.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -558,6 +569,14 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await expect(await suggested.cardCTA).toContainText(
                 data.newCtaText,
             );
+            await expect(await suggested.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(suggested.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -754,12 +773,11 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await ost.checkoutLinkUse.click();
         });
 
-        // uncomment once MWPW-169011 is fixed
-        // await test.step('step-7: Validate promo removed in Editor panel', async () => {
-        //     await expect(
-        //         await studio.editorPanel.locator(studio.editorCTA),
-        //     ).not.toHaveAttribute('data-promotion-code');
-        // });
+        await test.step('step-7: Validate promo removed in Editor panel', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorCTA),
+            ).not.toHaveAttribute('data-promotion-code');
+        });
 
         await test.step('step-8: Validate CTA promo removed from the card', async () => {
             await expect(await suggested.cardCTA).not.toHaveAttribute(
@@ -814,42 +832,39 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await expect(
                 await studio.editorPanel.locator(studio.editorVariant),
             ).toHaveAttribute('default-value', 'ah-try-buy-widget');
-
-            // *** uncomment once MWPW-164093 (AHome PR) is merged to main ***
-
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorSize),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorTitle),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorSubtitle),
-            // ).not.toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBadge),
-            // ).not.toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorDescription),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorIconURL),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBorderColor),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBackgroundColor),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorBackgroundImage),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorPrices),
-            // ).toBeVisible();
-            // await expect(
-            //     await studio.editorPanel.locator(studio.editorFooter),
-            // ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorSize),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorTitle),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorSubtitle),
+            ).not.toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBadge),
+            ).not.toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBorderColor),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundColor),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorPrices),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorFooter),
+            ).toBeVisible();
         });
 
         await test.step('step-5: Validate card variant change', async () => {
@@ -860,14 +875,19 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
                 await studio.getCard(data.cardid, 'suggested'),
             ).not.toBeVisible();
             await expect(await suggested.cardEyebrow).not.toBeVisible();
-
-            // *** uncomment once MWPW-164093 (AHome PR) is merged to main ***
-
-            // await expect(await trybuywidget.cardTitle).toBeVisible();
-            // await expect(await trybuywidget.cardDescription).toBeVisible();
-            // await expect(await trybuywidget.cardPrice).toBeVisible();
-            // await expect(await trybuywidget.cardCTA).toBeVisible();
-            // await expect(await trybuywidget.cardIcon).toBeVisible();
+            await expect(await trybuywidget.cardTitle).toBeVisible();
+            await expect(await trybuywidget.cardDescription).toBeVisible();
+            await expect(await trybuywidget.cardPrice).toBeVisible();
+            await expect(await trybuywidget.cardIcon).toBeVisible();
+            await expect(await trybuywidget.cardCTA).toBeVisible();
+            await expect(await trybuywidget.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await trybuywidget.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -1095,6 +1115,14 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
+            await expect(await suggested.cardCTA).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await suggested.cardCTA).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 });

--- a/nala/studio/ccd/suggested/tests/suggested_edit.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_edit.test.js
@@ -1057,7 +1057,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
     });
 
     // @studio-suggested-edit-cta-variant - Validate edit CTA variant for suggested card in mas studio
-    test(`${features[14].name},${features[14].tags}`, async ({
+    test.skip(`${features[14].name},${features[14].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ccd/suggested/tests/suggested_save.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_save.test.js
@@ -2,6 +2,8 @@ import { expect, test } from '@playwright/test';
 import StudioPage from '../../../studio.page.js';
 import CCDSuggestedSpec from '../specs/suggested_save.spec.js';
 import CCDSuggestedPage from '../suggested.page.js';
+import CCDSlicePage from '../../slice/slice.page.js';
+import AHTryBuyWidgetPage from '../../../ahome/try-buy-widget/try-buy-widget.page.js';
 import OSTPage from '../../../ost.page.js';
 import WebUtil from '../../../../libs/webutil.js';
 
@@ -10,6 +12,8 @@ const miloLibs = process.env.MILO_LIBS || '';
 
 let studio;
 let suggested;
+let slice;
+let trybuywidget;
 let ost;
 let clonedCardID;
 let webUtil;
@@ -23,6 +27,8 @@ test.beforeEach(async ({ page, browserName }) => {
     }
     studio = new StudioPage(page);
     suggested = new CCDSuggestedPage(page);
+    slice = new CCDSlicePage(page);
+    trybuywidget = new AHTryBuyWidgetPage(page);
     ost = new OSTPage(page);
     clonedCardID = '';
     webUtil = new WebUtil(page);
@@ -335,6 +341,14 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'slice'),
             ).toBeVisible();
+            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA)).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA)).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -404,6 +418,14 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
             ).toBeVisible();
+            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 
@@ -571,6 +593,14 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
+            await expect(await clonedCard.locator(suggested.cardCTA)).toHaveAttribute(
+                'data-wcs-osi',
+                data.osi,
+            );
+            await expect(await clonedCard.locator(suggested.cardCTA)).toHaveAttribute(
+                'is',
+                'checkout-button',
+            );
         });
     });
 });

--- a/nala/studio/ccd/suggested/tests/suggested_save.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_save.test.js
@@ -825,7 +825,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
     });
 
     // @studio-suggested-save-edit-cta-variant - Validate saving change CTA variant
-    test(`${features[11].name},${features[11].tags}`, async ({
+    test.skip(`${features[11].name},${features[11].tags}`, async ({
         page,
         baseURL,
     }) => {

--- a/nala/studio/ccd/suggested/tests/suggested_save.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_save.test.js
@@ -404,7 +404,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
         });
     });
 
-    // @studio-suggested-save-change-osi - Validate saving change osi
+    // @studio-suggested-save-edit-osi - Validate saving change osi
     test(`${features[4].name},${features[4].tags}`, async ({
         page,
         baseURL,

--- a/nala/studio/ccd/suggested/tests/suggested_save.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_save.test.js
@@ -55,159 +55,13 @@ test.afterEach(async ({ page }) => {
 });
 
 test.describe('M@S Studio CCD Suggested card test suite', () => {
-    // @studio-suggested-clone-edit-save-delete - Clone Field & Edit card, edit, save then delete suggested card
+    // @studio-suggested-remove-correct-fragment - Clone card then delete, verify the correct card is removed from screen
     test(`${features[0].name},${features[0].tags}`, async ({
         page,
         baseURL,
     }) => {
         const { data } = features[0];
         const testPage = `${baseURL}${features[0].path}${miloLibs}${features[0].browserParams}${data.cardid}`;
-        console.info('[Test Page]: ', testPage);
-
-        await test.step('step-1: Go to MAS Studio test page', async () => {
-            await page.goto(testPage);
-            await page.waitForLoadState('domcontentloaded');
-        });
-
-        await test.step('step-2: Open card editor', async () => {
-            await expect(
-                await studio.getCard(data.cardid, 'suggested'),
-            ).toBeVisible();
-            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
-            await expect(await studio.editorPanel).toBeVisible();
-        });
-
-        await test.step('step-3: Clone card and open editor', async () => {
-            await studio.cloneCard();
-            let clonedCard = await studio.getCard(
-                data.cardid,
-                'suggested',
-                'cloned',
-            );
-            clonedCardID = await clonedCard
-                .locator('aem-fragment')
-                .getAttribute('fragment');
-            data.clonedCardID = await clonedCardID;
-            await expect(await clonedCard).toBeVisible();
-            await clonedCard.dblclick();
-            await page.waitForTimeout(2000);
-        });
-
-        await test.step('step-4: Edit fields and save card', async () => {
-            await expect(
-                await studio.editorPanel.locator(studio.editorTitle),
-            ).toBeVisible();
-            await expect(
-                await studio.editorPanel.locator(studio.editorTitle),
-            ).toHaveValue(data.title);
-            // edit price
-            await (
-                await studio.editorPanel.locator(studio.regularPrice)
-            ).dblclick();
-            await expect(await ost.price).toBeVisible();
-            await expect(await ost.priceUse).toBeVisible();
-            await expect(await ost.oldPriceCheckbox).toBeVisible();
-            await ost.oldPriceCheckbox.click();
-            await ost.priceUse.click();
-            // edit CTA
-            await studio.editorCTA.click();
-            await studio.editorPanel
-                .locator(studio.editorFooter)
-                .locator(studio.linkEdit)
-                .click();
-            await expect(await studio.linkText).toBeVisible();
-            await expect(await studio.linkSave).toBeVisible();
-            await expect(await studio.linkText).toHaveValue(data.ctaText);
-            await studio.linkText.fill(data.newCtaText);
-            await studio.linkSave.click();
-            // edit title
-            await studio.editorPanel
-                .locator(studio.editorTitle)
-                .fill(data.newTitle);
-            // edit eyebrow
-            await studio.editorPanel
-                .locator(studio.editorSubtitle)
-                .fill(data.newSubtitle);
-            // edit mnemonic URL
-            await studio.editorPanel
-                .locator(studio.editorIconURL)
-                .fill(data.newIconURL);
-            // edit descritpion
-            await studio.editorPanel
-                .locator(studio.editorDescription)
-                .fill(data.newDescription);
-            // save card
-            await studio.saveCard();
-        });
-
-        await test.step('step-5: Validate edited fields in Editor panel', async () => {
-            await expect(
-                await studio.editorPanel.locator(studio.editorTitle),
-            ).toHaveValue(data.newTitle);
-            await expect(
-                await studio.editorPanel.locator(studio.editorSubtitle),
-            ).toHaveValue(data.newSubtitle);
-            await expect(
-                await studio.editorPanel.locator(studio.editorIconURL),
-            ).toHaveValue(data.newIconURL);
-            expect(
-                await studio.editorPanel
-                    .locator(studio.editorDescription)
-                    .innerText(),
-            ).toBe(data.newDescription);
-            await expect(
-                await studio.editorPanel.locator(studio.editorPrices),
-            ).toContainText(data.price);
-            await expect(
-                await studio.editorPanel.locator(studio.editorPrices),
-            ).not.toContainText(data.strikethroughPrice);
-            await expect(
-                await studio.editorPanel.locator(studio.editorFooter),
-            ).toContainText(data.newCtaText);
-        });
-
-        await test.step('step-6: Search for the cloned card and verify changes then delete the card', async () => {
-            const clonedCard = await studio.getCard(
-                data.clonedCardID,
-                'suggested',
-            );
-            await expect(
-                await clonedCard.locator(suggested.cardTitle),
-            ).toHaveText(data.newTitle);
-            await expect(
-                await clonedCard.locator(suggested.cardEyebrow),
-            ).toHaveText(data.newSubtitle);
-            await expect(
-                await clonedCard.locator(suggested.cardDescription),
-            ).toHaveText(data.newDescription);
-            await expect(
-                await clonedCard.locator(suggested.cardIcon),
-            ).toHaveAttribute('src', data.newIconURL);
-            await expect(
-                await clonedCard.locator(suggested.cardPrice),
-            ).toContainText(data.price);
-            await expect(
-                await clonedCard.locator(suggested.cardPrice),
-            ).not.toContainText(data.strikethroughPrice);
-            await expect(
-                await clonedCard.locator(suggested.cardCTA),
-            ).toContainText(data.newCtaText);
-
-            // delete card
-            await studio.deleteCard();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'suggested'),
-            ).not.toBeVisible();
-        });
-    });
-
-    // @studio-suggested-remove-correct-fragment - Clone card then delete, verify the correct card is removed from screen
-    test(`${features[1].name},${features[1].tags}`, async ({
-        page,
-        baseURL,
-    }) => {
-        const { data } = features[1];
-        const testPage = `${baseURL}${features[1].path}${miloLibs}${features[1].browserParams}${data.cardid}`;
         console.info('[Test Page]: ', testPage);
 
         await test.step('step-1: Go to MAS Studio test page', async () => {
@@ -276,6 +130,84 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
     });
 
     // @studio-suggested-save-variant-change-to-slice - Validate saving card after variant change to ccd slice
+    test(`${features[1].name},${features[1].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[1];
+        const testPage = `${baseURL}${features[1].path}${miloLibs}${features[1].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            let clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Change variant and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorVariant),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorVariant),
+            ).toHaveAttribute('default-value', 'ccd-suggested');
+            await studio.editorPanel
+                .locator(studio.editorVariant)
+                .locator('sp-picker')
+                .first()
+                .click();
+            await page.getByRole('option', { name: 'slice' }).click();
+            await page.waitForTimeout(2000);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate variant change', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorVariant),
+            ).toHaveAttribute('default-value', 'ccd-slice');
+            await expect(
+                await studio.getCard(data.clonedCardID, 'suggested'),
+            ).not.toBeVisible();
+            await expect(
+                await studio.getCard(data.clonedCardID, 'slice'),
+            ).toBeVisible();
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'slice')
+                ).locator(slice.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'slice')
+                ).locator(slice.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
+        });
+    });
+
+    // @studio-suggested-save-variant-change-to-trybuywidget - Validate saving card after variant change to AHome try-buy-widget
     test(`${features[2].name},${features[2].tags}`, async ({
         page,
         baseURL,
@@ -325,88 +257,8 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
                 .locator('sp-picker')
                 .first()
                 .click();
-            await page.getByRole('option', { name: 'slice' }).click();
-            await page.waitForTimeout(2000);
-            // save card
-            await studio.saveCard();
-        });
-
-        await test.step('step-5: Validate variant change', async () => {
-            await expect(
-                await studio.editorPanel.locator(studio.editorVariant),
-            ).toHaveAttribute('default-value', 'ccd-slice');
-            await expect(
-                await studio.getCard(data.clonedCardID, 'suggested'),
-            ).not.toBeVisible();
-            await expect(
-                await studio.getCard(data.clonedCardID, 'slice'),
-            ).toBeVisible();
-            await expect(
-                await (
-                    await studio.getCard(data.clonedCardID, 'slice')
-                ).locator(slice.cardCTA),
-            ).toHaveAttribute('data-wcs-osi', data.osi);
-            await expect(
-                await (
-                    await studio.getCard(data.clonedCardID, 'slice')
-                ).locator(slice.cardCTA),
-            ).toHaveAttribute('is', 'checkout-button');
-        });
-    });
-
-    // @studio-suggested-save-variant-change-to-trybuywidget - Validate saving card after variant change to AHome try-buy-widget
-    test(`${features[3].name},${features[3].tags}`, async ({
-        page,
-        baseURL,
-    }) => {
-        const { data } = features[3];
-        const testPage = `${baseURL}${features[3].path}${miloLibs}${features[3].browserParams}${data.cardid}`;
-        console.info('[Test Page]: ', testPage);
-
-        await test.step('step-1: Go to MAS Studio test page', async () => {
-            await page.goto(testPage);
-            await page.waitForLoadState('domcontentloaded');
-        });
-
-        await test.step('step-2: Open card editor', async () => {
-            await expect(
-                await studio.getCard(data.cardid, 'suggested'),
-            ).toBeVisible();
-            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
-            await expect(await studio.editorPanel).toBeVisible();
-        });
-
-        await test.step('step-3: Clone card and open editor', async () => {
-            await studio.cloneCard();
-            let clonedCard = await studio.getCard(
-                data.cardid,
-                'suggested',
-                'cloned',
-            );
-            clonedCardID = await clonedCard
-                .locator('aem-fragment')
-                .getAttribute('fragment');
-            data.clonedCardID = await clonedCardID;
-            await expect(await clonedCard).toBeVisible();
-            await clonedCard.dblclick();
-            await page.waitForTimeout(2000);
-        });
-
-        await test.step('step-4: Change variant and save card', async () => {
-            await expect(
-                await studio.editorPanel.locator(studio.editorVariant),
-            ).toBeVisible();
-            await expect(
-                await studio.editorPanel.locator(studio.editorVariant),
-            ).toHaveAttribute('default-value', 'ccd-suggested');
-            await studio.editorPanel
-                .locator(studio.editorVariant)
-                .locator('sp-picker')
-                .first()
-                .click();
             await page.getByRole('option', { name: 'try buy widget' }).click();
             await page.waitForTimeout(2000);
-            // save card
             await studio.saveCard();
         });
 
@@ -433,13 +285,467 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
         });
     });
 
-    // @studio-suggested-save-edit-osi - Validate saving change osi
+    // @studio-suggested-save-edit-title - Validate saving card after editing card title
+    test(`${features[3].name},${features[3].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[3];
+        const testPage = `${baseURL}${features[3].path}${miloLibs}${features[3].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit title and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorTitle),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorTitle),
+            ).toHaveValue(data.title);
+            await studio.editorPanel
+                .locator(studio.editorTitle)
+                .fill(data.newTitle);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card title', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorTitle),
+            ).toHaveValue(data.newTitle);
+            await expect(
+                await clonedCard.locator(suggested.cardTitle),
+            ).toHaveText(data.newTitle);
+        });
+    });
+
+    // @studio-suggested-save-edit-eyebrow - Validate saving card after editing card eyebrow
     test(`${features[4].name},${features[4].tags}`, async ({
         page,
         baseURL,
     }) => {
         const { data } = features[4];
         const testPage = `${baseURL}${features[4].path}${miloLibs}${features[4].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit eyebrow and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorSubtitle),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorSubtitle),
+            ).toHaveValue(data.subtitle);
+            await studio.editorPanel
+                .locator(studio.editorSubtitle)
+                .fill(data.newSubtitle);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card eyebrow', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorSubtitle),
+            ).toHaveValue(data.newSubtitle);
+            await expect(
+                await clonedCard.locator(suggested.cardEyebrow),
+            ).toHaveText(data.newSubtitle);
+        });
+    });
+
+    // @studio-suggested-save-edit-mnemonic - Validate saving card after editing card mnemonic
+    test(`${features[5].name},${features[5].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[5];
+        const testPage = `${baseURL}${features[5].path}${miloLibs}${features[5].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit mnemonic and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toHaveValue(data.iconURL);
+            await studio.editorPanel
+                .locator(studio.editorIconURL)
+                .fill(data.newIconURL);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card mnemonic', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorIconURL),
+            ).toHaveValue(data.newIconURL);
+            await expect(
+                await clonedCard.locator(suggested.cardIcon),
+            ).toHaveAttribute('src', data.newIconURL);
+        });
+    });
+
+    // @studio-suggested-save-edit-description - Validate saving card after editing card description
+    test(`${features[6].name},${features[6].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[6];
+        const testPage = `${baseURL}${features[6].path}${miloLibs}${features[6].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit description and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toContainText(data.description);
+            await studio.editorPanel
+                .locator(studio.editorDescription)
+                .fill(data.newDescription);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card description', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorDescription),
+            ).toContainText(data.newDescription);
+            await expect(
+                await clonedCard.locator(suggested.cardDescription),
+            ).toHaveText(data.newDescription);
+        });
+    });
+
+    // @studio-suggested-save-edit-image - Validate saving card after editing card background image
+    test(`${features[7].name},${features[7].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[7];
+        const testPage = `${baseURL}${features[7].path}${miloLibs}${features[7].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit fields and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toHaveValue('');
+            await studio.editorPanel
+                .locator(studio.editorBackgroundImage)
+                .fill(data.newBackgroundURL);
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card image', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorBackgroundImage),
+            ).toHaveValue(data.newBackgroundURL);
+            await expect(await clonedCard).toHaveAttribute(
+                'background-image',
+                data.newBackgroundURL,
+            );
+        });
+    });
+
+    // @studio-suggested-save-edit-price - Validate saving card after editing card price
+    test(`${features[8].name},${features[8].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[8];
+        const testPage = `${baseURL}${features[8].path}${miloLibs}${features[8].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit price and save card', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorPrices),
+            ).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorPrices),
+            ).toContainText(data.price);
+            await expect(
+                await studio.editorPanel.locator(studio.editorPrices),
+            ).toContainText(data.strikethroughPrice);
+            await (
+                await studio.editorPanel.locator(studio.regularPrice)
+            ).dblclick();
+            await expect(await ost.price).toBeVisible();
+            await expect(await ost.priceUse).toBeVisible();
+            await expect(await ost.oldPriceCheckbox).toBeVisible();
+            await ost.oldPriceCheckbox.click();
+            await ost.priceUse.click();
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card price', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorPrices),
+            ).toContainText(data.price);
+            await expect(
+                await studio.editorPanel.locator(studio.editorPrices),
+            ).not.toContainText(data.strikethroughPrice);
+            await expect(
+                await clonedCard.locator(suggested.cardPrice),
+            ).toContainText(data.price);
+            await expect(
+                await clonedCard.locator(suggested.cardPrice),
+            ).not.toContainText(data.strikethroughPrice);
+        });
+    });
+
+    // @studio-suggested-save-edit-cta - Validate saving card after editing card cta
+    test(`${features[9].name},${features[9].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[9];
+        const testPage = `${baseURL}${features[9].path}${miloLibs}${features[9].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+        let clonedCard;
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Open card editor', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).dblclick();
+            await expect(await studio.editorPanel).toBeVisible();
+        });
+
+        await test.step('step-3: Clone card and open editor', async () => {
+            await studio.cloneCard();
+            clonedCard = await studio.getCard(
+                data.cardid,
+                'suggested',
+                'cloned',
+            );
+            clonedCardID = await clonedCard
+                .locator('aem-fragment')
+                .getAttribute('fragment');
+            data.clonedCardID = await clonedCardID;
+            await expect(await clonedCard).toBeVisible();
+            await clonedCard.dblclick();
+            await page.waitForTimeout(2000);
+        });
+
+        await test.step('step-4: Edit cta and save card', async () => {
+            await expect(await studio.editorCTA).toBeVisible();
+            await expect(
+                await studio.editorPanel.locator(studio.editorFooter),
+            ).toContainText(data.ctaText);
+            await studio.editorCTA.click();
+            await studio.editorPanel
+                .locator(studio.editorFooter)
+                .locator(studio.linkEdit)
+                .click();
+            await expect(await studio.linkText).toBeVisible();
+            await expect(await studio.linkSave).toBeVisible();
+            await expect(await studio.linkText).toHaveValue(data.ctaText);
+            await studio.linkText.fill(data.newCtaText);
+            await studio.linkSave.click();
+            await studio.saveCard();
+        });
+
+        await test.step('step-5: Validate edited card cta', async () => {
+            await expect(
+                await studio.editorPanel.locator(studio.editorFooter),
+            ).toContainText(data.newCtaText);
+            await expect(
+                await clonedCard.locator(suggested.cardCTA),
+            ).toContainText(data.newCtaText);
+        });
+    });
+
+    // @studio-suggested-save-edit-osi - Validate saving change osi
+    test(`${features[10].name},${features[10].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[10];
+        const testPage = `${baseURL}${features[10].path}${miloLibs}${features[10].browserParams}${data.cardid}`;
         console.info('[Test Page]: ', testPage);
 
         await test.step('step-1: Go to MAS Studio test page', async () => {
@@ -482,7 +788,6 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await (await ost.nextButton).click();
             await expect(await ost.priceUse).toBeVisible();
             await ost.priceUse.click();
-            // save card
             await studio.saveCard();
         });
 
@@ -520,12 +825,12 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
     });
 
     // @studio-suggested-save-edit-cta-variant - Validate saving change CTA variant
-    test(`${features[5].name},${features[5].tags}`, async ({
+    test(`${features[11].name},${features[11].tags}`, async ({
         page,
         baseURL,
     }) => {
-        const { data } = features[5];
-        const testPage = `${baseURL}${features[5].path}${miloLibs}${features[5].browserParams}${data.cardid}`;
+        const { data } = features[11];
+        const testPage = `${baseURL}${features[11].path}${miloLibs}${features[11].browserParams}${data.cardid}`;
         console.info('[Test Page]: ', testPage);
         let clonedCard;
 
@@ -584,7 +889,6 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             ).toBeVisible();
             await (await studio.getLinkVariant(data.newVariant)).click();
             await studio.linkSave.click();
-            // save card
             await studio.saveCard();
         });
 

--- a/nala/studio/ccd/suggested/tests/suggested_save.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_save.test.js
@@ -341,14 +341,16 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'slice'),
             ).toBeVisible();
-            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA)).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await (await studio.getCard(data.clonedCardID, 'slice')).locator(slice.cardCTA)).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'slice')
+                ).locator(slice.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'slice')
+                ).locator(slice.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
@@ -418,14 +420,16 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await expect(
                 await studio.getCard(data.clonedCardID, 'ahtrybuywidget'),
             ).toBeVisible();
-            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await (await studio.getCard(data.clonedCardID, 'ahtrybuywidget')).locator(trybuywidget.cardCTA)).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
+                ).locator(trybuywidget.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await (
+                    await studio.getCard(data.clonedCardID, 'ahtrybuywidget')
+                ).locator(trybuywidget.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 
@@ -593,14 +597,12 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
                     data.newCtaCSS,
                 ),
             ).toBeTruthy();
-            await expect(await clonedCard.locator(suggested.cardCTA)).toHaveAttribute(
-                'data-wcs-osi',
-                data.osi,
-            );
-            await expect(await clonedCard.locator(suggested.cardCTA)).toHaveAttribute(
-                'is',
-                'checkout-button',
-            );
+            await expect(
+                await clonedCard.locator(suggested.cardCTA),
+            ).toHaveAttribute('data-wcs-osi', data.osi);
+            await expect(
+                await clonedCard.locator(suggested.cardCTA),
+            ).toHaveAttribute('is', 'checkout-button');
         });
     });
 });

--- a/nala/studio/ccd/suggested/tests/suggested_save.test.js
+++ b/nala/studio/ccd/suggested/tests/suggested_save.test.js
@@ -493,7 +493,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
         });
     });
 
-    // @studio-suggested-save-edit-cta-variant - Validate saving change cta variant
+    // @studio-suggested-save-edit-cta-variant - Validate saving change CTA variant
     test(`${features[5].name},${features[5].tags}`, async ({
         page,
         baseURL,
@@ -532,7 +532,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await page.waitForTimeout(2000);
         });
 
-        await test.step('step-4: Edit cta variant and save card', async () => {
+        await test.step('step-4: Edit CTA variant and save card', async () => {
             await expect(
                 await studio.editorPanel
                     .locator(studio.editorFooter)
@@ -562,7 +562,7 @@ test.describe('M@S Studio CCD Suggested card test suite', () => {
             await studio.saveCard();
         });
 
-        await test.step('step-5: Validate cta variant change', async () => {
+        await test.step('step-5: Validate CTA variant change', async () => {
             await expect(await studio.editorCTA).toHaveClass(data.newVariant);
             await expect(await studio.editorCTA).not.toHaveClass(data.variant);
             expect(

--- a/nala/studio/ost.page.js
+++ b/nala/studio/ost.page.js
@@ -34,7 +34,9 @@ export default class OSTPage {
         this.oldPriceCheckbox = page.locator(
             '//input[@value="displayOldPrice"]',
         );
-        this.priceUse = page.locator('div[id*="tabpanel-price"] button').first();
+        this.priceUse = page
+            .locator('div[id*="tabpanel-price"] button')
+            .first();
         this.priceOpticalUse = page
             .locator('button:near(:text("Optical price"))')
             .first();

--- a/nala/studio/studio.page.js
+++ b/nala/studio/studio.page.js
@@ -92,6 +92,26 @@ export default class StudioPage {
         // Edit Link Panel
         this.linkText = page.locator('#linkText input');
         this.linkSave = page.locator('#saveButton');
+        this.linkVariant = page.locator('#linkVariant');
+        this.accentVariant = page.locator('sp-button[variant="accent"]');
+        this.primaryVariant = page.locator(
+            'sp-button[variant="primary]:not([treatment="outline"]])',
+        );
+        this.primaryOutlineVariant = page.locator(
+            'sp-button[variant="primary"][treatment="outline"]',
+        );
+        this.secondaryVariant = page.locator(
+            'sp-button[variant="secondary]:not([treatment="outline"]])',
+        );
+        this.secondaryOutlineVariant = page.locator(
+            'sp-button[variant="secondary"][treatment="outline"]',
+        );
+        this.primaryLinkVariant = page.locator(
+            'sp-link:has-text("Primary link")',
+        );
+        this.secondaryLinkVariant = page.locator(
+            'sp-link[variant="secondary"]',
+        );
     }
 
     async getCard(id, cardType, cloned, secondID) {
@@ -147,11 +167,28 @@ export default class StudioPage {
         await expect(await this.deleteCardButton).toBeEnabled();
         await this.deleteCardButton.click();
         await expect(await this.confirmationDialog).toBeVisible();
-        await this.confirmationDialog
-            .locator(this.deleteDialog)
-            .click();
+        await this.confirmationDialog.locator(this.deleteDialog).click();
         await expect(await this.toastPositive).toHaveText(
             'Fragment successfully deleted.',
         );
+    }
+
+    async getLinkVariant(variant) {
+        const linkVariant = {
+            accent: this.accentVariant,
+            primary: this.primaryVariant,
+            'primary-outline': this.primaryOutlineVariant,
+            secondary: this.secondaryVariant,
+            'secondary-outline': this.secondaryOutlineVariant,
+            'primary-link': this.primaryLinkVariant,
+            'secondary-link': this.secondaryLinkVariant,
+        };
+
+        const link = linkVariant[variant];
+        if (!link) {
+            throw new Error(`Invalid link variant type: ${variant}`);
+        }
+
+        return this.linkVariant.locator(link);
     }
 }

--- a/nala/studio/studio.spec.js
+++ b/nala/studio/studio.spec.js
@@ -63,5 +63,15 @@ export default {
             browserParams: '#query=',
             tags: '@mas-studio @ccd @ccd-slice',
         },
+        {
+            tcid: '7',
+            name: '@studio-card-dblclick-info',
+            path: '/studio.html',
+            data: {
+                cardid: '206a8742-0289-4196-92d4-ced99ec4191e',
+            },
+            browserParams: '#query=',
+            tags: '@mas-studio @ccd @ccd-suggested',
+        },
     ],
 };

--- a/nala/studio/studio.test.js
+++ b/nala/studio/studio.test.js
@@ -296,5 +296,4 @@ test.describe('M@S Studio feature test suite', () => {
             );
         });
     });
-
 });

--- a/nala/studio/studio.test.js
+++ b/nala/studio/studio.test.js
@@ -271,4 +271,30 @@ test.describe('M@S Studio feature test suite', () => {
             ).toBeVisible();
         });
     });
+
+    // @studio-card-dblclick-info - Validate message for double-click on the card in mas studio
+    test(`${features[7].name},${features[7].tags}`, async ({
+        page,
+        baseURL,
+    }) => {
+        const { data } = features[7];
+        const testPage = `${baseURL}${features[7].path}${miloLibs}${features[7].browserParams}${data.cardid}`;
+        console.info('[Test Page]: ', testPage);
+
+        await test.step('step-1: Go to MAS Studio test page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Validate double-click message', async () => {
+            await expect(
+                await studio.getCard(data.cardid, 'suggested'),
+            ).toBeVisible();
+            await (await studio.getCard(data.cardid, 'suggested')).click();
+            await expect(page.locator('sp-tooltip')).toHaveText(
+                'Double click the card to start editing.',
+            );
+        });
+    });
+
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,5 @@
 import { devices } from '@playwright/test';
 
-// const envs = require('./envs/envs.js');
-
 /**
  * @see https://playwright.dev/docs/test-configuration
  * @type {import('@playwright/test').PlaywrightTestConfig}


### PR DESCRIPTION
Adding tests to validate CTA variant change. Though skipped till the fix is merged (https://github.com/adobecom/mas/pull/179)

Additionally:
- adds validation of checkout link when cta is edited
- adds test to validate info message for double-clicking the card
- refactors save tests to separate them for each field (more informative if only one field is an issue)

Resolve [MWPW-169148](https://jira.corp.adobe.com/browse/MWPW-169148)

Test URLs:
- Before: https://main--mas--adobecom.aem.live
- After: https://MWPW-169148--mas--adobecom.aem.live
