### PR TITLE
MWPW-170036 fixing adobe-home surface cards

### DIFF
--- a/io/studio/src/fragment/paths.js
+++ b/io/studio/src/fragment/paths.js
@@ -6,7 +6,7 @@ const FRAGMENT_AUTHOR_URL_PREFIX =
     'https://author-p22655-e59433.adobeaemcloud.com/adobe/sites/cf/fragments';
 
 const PATH_TOKENS =
-    /\/content\/dam\/mas\/(?<surface>[\w]+)\/(?<parsedLocale>[\w_]+)\/(?<fragmentPath>.*)/;
+    /\/content\/dam\/mas\/(?<surface>[\w_-]+)\/(?<parsedLocale>[\w_-]+)\/(?<fragmentPath>.*)/;
 
 /**
  * builds a full fetchable path to the fragment

--- a/io/www/src/fragment/paths.js
+++ b/io/www/src/fragment/paths.js
@@ -3,7 +3,7 @@ const MAS_ROOT = '/content/dam/mas';
 const FRAGMENT_URL_PREFIX = 'https://odin.adobe.com/adobe/sites/fragments';
 
 const PATH_TOKENS =
-    /\/content\/dam\/mas\/(?<surface>[\w]+)\/(?<parsedLocale>[\w_]+)\/(?<fragmentPath>.+)/;
+    /\/content\/dam\/mas\/(?<surface>[\w-_]+)\/(?<parsedLocale>[\w-_]+)\/(?<fragmentPath>.+)/;
 
 /**
  * builds a full fetchable path to the fragment

--- a/io/www/src/fragment/pipeline.js
+++ b/io/www/src/fragment/pipeline.js
@@ -59,7 +59,10 @@ async function main(params) {
     }
 
     for (const transformer of [fetchFragment, translate, collection, replace]) {
-        if (context.status != 200) break;
+        if (context.status != 200) {
+            logError(context.message, context);
+            break;
+        }
         context.transformer = transformer.name;
         context = await transformer(context);
     }
@@ -100,7 +103,9 @@ async function main(params) {
             'Last-Modified': lastModified.toUTCString(),
         };
     } else {
-        returnValue.message = context.message;
+        returnValue.body = {
+            message: context.message,
+        };
     }
     const endTime = Date.now();
     log(

--- a/io/www/src/fragment/translate.js
+++ b/io/www/src/fragment/translate.js
@@ -1,11 +1,6 @@
 const { PATH_TOKENS, odinPath } = require('./paths.js');
 const { fetch, log } = require('./common.js');
 
-const NO_TRANSLATION_FOUND = {
-    status: 404,
-    message: 'no translation found',
-};
-
 /**
  * we expect a body to already have been fetched, and a locale to be requested.
  * This transformer name is a bit abusive: it just fetches a translation if the locale is different from the source locale.
@@ -25,14 +20,20 @@ async function translate(context) {
         const translatedPath = odinPath(surface, locale, fragmentPath);
         const response = await fetch(translatedPath, context);
         if (response.status != 200) {
-            return NO_TRANSLATION_FOUND;
+            return {
+                status: 500,
+                message: 'translation search failed',
+            };
         }
         const root = await response.json();
         if (root?.items?.length == 1) {
             translatedBody = root.items[0];
             context.translatedId = translatedBody.id;
         } else {
-            return NO_TRANSLATION_FOUND;
+            return {
+                status: 404,
+                message: 'no translation found',
+            };
         }
     } else {
         log('no translation needed', context);

--- a/io/www/test/fragment/paths.test.js
+++ b/io/www/test/fragment/paths.test.js
@@ -1,0 +1,14 @@
+const { expect } = require('chai');
+const { PATH_TOKENS } = require('../../src/fragment/paths');
+
+describe('PATH_TOKENS', () => {
+    it('should work with adobe-home surface', async () => {
+        const match = '/content/dam/mas/adobe-home/en_US/myadobehomecard'.match(
+            PATH_TOKENS,
+        );
+        expect(match).to.not.be?.null;
+        expect(match).to.not.be?.undefined;
+        const { surface } = match.groups;
+        expect(surface).to.equal('adobe-home');
+    });
+});

--- a/io/www/test/fragment/pipeline.test.js
+++ b/io/www/test/fragment/pipeline.test.js
@@ -184,7 +184,9 @@ describe('pipeline corner cases', () => {
             state: new MockState(),
         });
         expect(result).to.deep.equal({
-            message: 'requested parameters are not present',
+            body: {
+                message: 'requested parameters are not present',
+            },
             statusCode: 400,
         });
     });
@@ -202,7 +204,9 @@ describe('pipeline corner cases', () => {
 
         expect(result).to.deep.equal({
             statusCode: 500,
-            message: 'nok',
+            body: {
+                message: 'nok',
+            },
         });
     });
 
@@ -221,7 +225,9 @@ describe('pipeline corner cases', () => {
 
         expect(result).to.deep.equal({
             statusCode: 404,
-            message: 'nok',
+            body: {
+                message: 'nok',
+            }
         });
     });
 
@@ -248,7 +254,9 @@ describe('pipeline corner cases', () => {
 
         expect(result).to.deep.equal({
             statusCode: 500,
-            message: 'unable to fetch references',
+            body: {
+                message: 'unable to fetch references',
+            },
         });
     });
 

--- a/io/www/test/fragment/translate.test.js
+++ b/io/www/test/fragment/translate.test.js
@@ -103,7 +103,7 @@ describe('translate corner cases', () => {
         });
     });
 
-    it('should return 404 when translation fetch fails', async () => {
+    it('should return 500 when translation fetch failed', async () => {
         nock('https://odin.adobe.com')
             .get('/adobe/sites/fragments')
             .query({ path: '/content/dam/mas/drafts/fr_FR/someFragment' })
@@ -117,8 +117,8 @@ describe('translate corner cases', () => {
             locale: 'fr_FR',
         });
         expect(result).to.deep.equal({
-            status: 404,
-            message: 'no translation found',
+            status: 500,
+            message: 'translation search failed',
         });
     });
 


### PR DESCRIPTION
- hyphen character was not taken in account in PATH_TOKENS, added a failing test + fix,
- improved logs with that use case,
- also fixed studio duplicate

Test URLs:
- Before: https://main--mas--adobecom.aem.live
- After: https://MWPW-170036--mas--adobecom.aem.live
