### PR TITLE
MWPW-164493 [Plans] Merch card for Plans page students tab

### DIFF
--- a/studio/src/editors/merch-card-editor.js
+++ b/studio/src/editors/merch-card-editor.js
@@ -18,8 +18,6 @@ class MerchCardEditor extends LitElement {
     static properties = {
         fragmentStore: { type: Object, attribute: false },
         updateFragment: { type: Function },
-        wide: { type: Boolean, state: true },
-        superWide: { type: Boolean, state: true },
         availableSizes: { type: Array, state: true },
         availableColors: { type: Array, state: true },
         availableBorderColors: { type: Array, state: true },
@@ -31,8 +29,6 @@ class MerchCardEditor extends LitElement {
     constructor() {
         super();
         this.updateFragment = null;
-        this.wide = false;
-        this.superWide = false;
         this.availableSizes = [];
         this.availableColors = [];
         this.availableBorderColors = [];
@@ -225,8 +221,6 @@ class MerchCardEditor extends LitElement {
             const field = this.querySelector(`sp-field-group.toggle#${key}`);
             if (field) field.style.display = 'block';
         });
-        this.wide = variant.size?.includes('wide');
-        this.superWide = variant.size?.includes('super-wide');
         this.showQuantityFields(this.quantitySelectorDisplayed);
         if (variant.borderColor) {
             const borderField = this.querySelector(
@@ -666,7 +660,7 @@ class MerchCardEditor extends LitElement {
     }
 
     get isPlans() {
-        return this.fragment.variant === 'plans';
+        return this.fragment.variant === 'plans' || this.fragment.variant === 'plans-edu';
     }
 
     get badge() {

--- a/studio/src/editors/variant-picker.js
+++ b/studio/src/editors/variant-picker.js
@@ -5,6 +5,7 @@ export const VARIANTS = [
     { label: 'All', value: 'all', surface: 'all' },
     { label: 'Catalog', value: 'catalog', surface: 'acom' },
     { label: 'Plans', value: 'plans', surface: 'acom' },
+    { label: 'Plans Students', value: 'plans-edu', surface: 'acom' },
     { label: 'Slice', value: 'ccd-slice', surface: 'ccd' },
     { label: 'Special offers', value: 'special-offers', surface: 'acom' },
     { label: 'Suggested', value: 'ccd-suggested', surface: 'ccd' },


### PR DESCRIPTION
Plans card for students tab. Will be used outside card collection. Requested width 568px.
Authored in MAS Studio with new variant "Plans students".

Resolve [MWPW-164493](https://jira.corp.adobe.com/browse/MWPW-164493)

Test URLs:
- Before: https://main--mas--adobecom.aem.live
- After: https://mwpw164493students--mas--adobecom.aem.live
