### PR TITLE
MWPW-167198: update commerce locale on locale filter change

### DIFF
--- a/studio.html
+++ b/studio.html
@@ -118,6 +118,7 @@
         <script src="https://www.adobe.com/libs/deps/imslib.min.js"></script>
     </head>
     <body class="spectrum spectrum--medium spectrum--light">
+        <mas-commerce-service></mas-commerce-service>
         <main>
             <sp-theme color="light" scale="medium"> </sp-theme>
         </main>

--- a/studio/src/rte/ost.js
+++ b/studio/src/rte/ost.js
@@ -253,8 +253,7 @@ export function openOfferSelectorTool(triggerElement, offerElement) {
         ostRoot.style.display = 'block';
         closeFunction = window.ost.openOfferSelectorTool({
             ...ostDefaults,
-            country: masCommerceService.settings.country,
-            language: masCommerceService.settings.language,
+            ...masCommerceService.settings,
             rootElement: ostRoot,
             zIndex: 20,
             aosAccessToken,

--- a/studio/src/rte/ost.js
+++ b/studio/src/rte/ost.js
@@ -20,9 +20,9 @@ export const ostDefaults = {
     aosApiKey: 'wcms-commerce-ims-user-prod',
     checkoutClientId: 'creative',
     country: 'US',
+    language: 'en',
     environment: 'PROD',
     landscape: 'PUBLISHED',
-    language: 'en',
     searchParameters: {},
     searchOfferSelectorId: null,
     defaultPlaceholderOptions: {
@@ -247,9 +247,14 @@ export function openOfferSelectorTool(triggerElement, offerElement) {
                 if (value) searchParameters.append(key, value);
             });
         }
+        const masCommerceService = document.querySelector(
+            'mas-commerce-service',
+        );
         ostRoot.style.display = 'block';
         closeFunction = window.ost.openOfferSelectorTool({
             ...ostDefaults,
+            country: masCommerceService.settings.country,
+            language: masCommerceService.settings.language,
             rootElement: ostRoot,
             zIndex: 20,
             aosAccessToken,

--- a/studio/src/studio.js
+++ b/studio/src/studio.js
@@ -51,7 +51,7 @@ class MasStudio extends LitElement {
         baseUrl: { type: String, attribute: 'base-url' },
     };
 
-    #localeFilterSubscription;
+    #unsubscribeLocaleObserver;
 
     constructor() {
         super();
@@ -64,18 +64,19 @@ class MasStudio extends LitElement {
     }
 
     subscribeLocaleObserver() {
-        this.#localeFilterSubscription = Store.filters.subscribe(
-            (value, oldValue) => {
-                if (value.locale !== oldValue.locale) {
-                    this.renderCommerceService();
-                }
-            },
-        );
+        const subscription = (value, oldValue) => {
+            if (value.locale !== oldValue.locale) {
+                this.renderCommerceService();
+            }
+        };
+        Store.filters.subscribe(subscription);
+        this.#unsubscribeLocaleObserver = () =>
+            Store.filters.unsubscribe(subscription);
     }
 
     disconnectedCallback() {
         super.disconnectedCallback();
-        this.#localeFilterSubscription.unsubscribe();
+        this.#unsubscribeLocaleObserver();
     }
 
     createRenderRoot() {

--- a/studio/src/studio.js
+++ b/studio/src/studio.js
@@ -51,25 +51,31 @@ class MasStudio extends LitElement {
         baseUrl: { type: String, attribute: 'base-url' },
     };
 
+    #localeFilterSubscription;
+
     constructor() {
         super();
         this.bucket = 'e59433';
     }
 
-    toggleCommerce(env) {
-        const service = this.querySelector('mas-commerce-service');
-        const newService = service.cloneNode(true);
-        newService.setAttribute('env', env);
-        service.remove();
-        this.prepend(newService);
-    }
-
     connectedCallback() {
         super.connectedCallback();
+        this.subscribeLocaleObserver();
+    }
+
+    subscribeLocaleObserver() {
+        this.#localeFilterSubscription = Store.filters.subscribe(
+            (value, oldValue) => {
+                if (value.locale !== oldValue.locale) {
+                    this.renderCommerceService();
+                }
+            },
+        );
     }
 
     disconnectedCallback() {
         super.disconnectedCallback();
+        this.#localeFilterSubscription.unsubscribe();
     }
 
     createRenderRoot() {
@@ -111,13 +117,22 @@ class MasStudio extends LitElement {
         return html`<mas-recently-updated></mas-recently-updated>`;
     }
 
+    renderCommerceService() {
+        const commerceService = document.querySelector('mas-commerce-service');
+        const env =
+            this.commerceEnv.value === WCS_ENV_STAGE
+                ? WCS_ENV_STAGE
+                : WCS_ENV_PROD;
+        commerceService.outerHTML = `<mas-commerce-service env="${env}" locale="${Store.filters.value.locale}"></mas-commerce-service>`;
+    }
+
+    update() {
+        super.update();
+        this.renderCommerceService();
+    }
+
     render() {
         return html`
-            ${this.commerceEnv.value === WCS_ENV_STAGE
-                ? html`<mas-commerce-service
-                      env="${WCS_ENV_STAGE}"
-                  ></mas-commerce-service>`
-                : html`<mas-commerce-service></mas-commerce-service>`}
             <mas-top-nav aem-env="${this.aemEnv}"></mas-top-nav>
             <mas-repository
                 bucket="${this.bucket}"


### PR DESCRIPTION
This change updates mas-commerce-service to render offers with the right locale when the locale filter changes.


Resolves https://jira.corp.adobe.com/browse/MWPW-167198

Test URLs:
- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-167198--mas--adobecom.aem.live/
