### PR TITLE
add checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 
 Resolves https://jira.corp.adobe.com/browse/MWPW-NUMBER
 
+QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases
+
 Test URLs:
 - Before: https://main--mas--adobecom.aem.live/
 - After: https://mwpw-NUMBER--mas--adobecom.aem.live/


### PR DESCRIPTION
when we merge PRs there are still some things we check manually.
Adding a checklist wiki link in PR description