### PR TITLE
MWPW-171673: CTA link text to be placeholder like: {{ cta text }} in default for ACOM

### DIFF
--- a/studio/src/rte/ost.js
+++ b/studio/src/rte/ost.js
@@ -48,8 +48,12 @@ export const ostDefaults = {
 
         getSelectedText(searchParameters) {
             const ctaLabel = searchParameters.get('text');
-            const selectedText = this.ctaTexts.find(({ id, name }) =>
+            let selectedText;
+            if (ctaLabel)
+            selectedText = this.ctaTexts.find(({ id, name }) =>
                 [id, name].includes(ctaLabel),
+            ) || this.ctaTexts.find(({ id, name }) =>
+                [id, name].includes(ctaLabel.replace('{{' , '').replace('}}', '')),
             );
             if (selectedText) return selectedText.id;
             return ctaLabel || this.getDefaultText();
@@ -152,7 +156,7 @@ export function onPlaceholderSelect(
 
     const ctaText = CHECKOUT_CTA_TEXTS[options.ctaText]; // no placeholder key support.
     if (ctaText) {
-        attributes['text'] = ctaText;
+        attributes['text'] = Store.search.get().path === 'acom' ? `{{${options.ctaText}}}` : ctaText;
         attributes['data-analytics-id'] = options.ctaText;
     }
 


### PR DESCRIPTION
Resolves: [MWPW-171673](https://jira.corp.adobe.com/browse/MWPW-171673)

Test URLs:
- Before: https://main--mas--adobecom.aem.live/
- After: https://MWPW-162398--mas--adobecom.aem.live/
