### PR TITLE
MWPW-170692 Fragment title update

### DIFF
--- a/studio/src/editors/merch-card-editor.js
+++ b/studio/src/editors/merch-card-editor.js
@@ -695,12 +695,10 @@ class MerchCardEditor extends LitElement {
 
     #displayBadgeColorFields(text) {
         if (!this.isPlans) return;
-        document.querySelector('#badgeColor').style.display = text
-            ? 'block'
-            : 'none';
-        document.querySelector('#badgeBorderColor').style.display = text
-            ? 'block'
-            : 'none';
+        const badgeColorEl = document.querySelector('#badgeColor');
+        if (badgeColorEl) badgeColorEl.style.display = text ? 'block' : 'none';
+        const badgeBorderColorEl = document.querySelector('#badgeBorderColor');
+        if (badgeBorderColorEl) badgeBorderColorEl.style.display = text ? 'block' : 'none';
     }
 
     get badgeText() {
@@ -817,7 +815,7 @@ class MerchCardEditor extends LitElement {
         );
         this.availableBackgroundColors = {
             Default: undefined,
-            ...(variant.allowedColors ?? []),
+            ...(variant?.allowedColors ?? []),
         };
     }
 

--- a/studio/src/mas-content.js
+++ b/studio/src/mas-content.js
@@ -107,7 +107,7 @@ class MasContent extends LitElement {
         >
             <sp-table-head>
                 <sp-table-head-cell sortable>Title</sp-table-head-cell>
-                <sp-table-head-cell sortable>Name</sp-table-head-cell>
+                <sp-table-head-cell sortable>Path</sp-table-head-cell>
                 <slot name="headers"></slot>
                 <sp-table-head-cell sortable>Status</sp-table-head-cell>
                 <sp-table-head-cell sortable>Modified at</sp-table-head-cell>

--- a/studio/src/mas-fragment-table.js
+++ b/studio/src/mas-fragment-table.js
@@ -1,5 +1,7 @@
 import { LitElement, html } from 'lit';
 import ReactiveController from './reactivity/reactive-controller.js';
+import { getFragmentPartsToUse, MODEL_WEB_COMPONENT_MAPPING } from './editor-panel.js';
+import Store from './store.js';
 
 class MasFragmentTable extends LitElement {
     static properties = {
@@ -20,11 +22,17 @@ class MasFragmentTable extends LitElement {
         super.update(changedProperties);
     }
 
+    getFragmentName(data) {
+        const webComponentName = MODEL_WEB_COMPONENT_MAPPING[data?.model?.path];
+        const fragmentParts = getFragmentPartsToUse(Store, data).fragmentParts;
+        return `${webComponentName}: ${fragmentParts}`;
+    }
+
     render() {
         const data = this.fragmentStore.value;
         return html`<sp-table-row value="${data.id}"
             ><sp-table-cell>${data.title}</sp-table-cell>
-            <sp-table-cell>${data.name}</sp-table-cell>
+            <sp-table-cell>${this.getFragmentName(data)}</sp-table-cell>
             ${this.customRender?.(data)}
             <sp-table-cell>${data.status}</sp-table-cell>
             <sp-table-cell>${data.modified.at}</sp-table-cell>

--- a/studio/src/mas-repository.js
+++ b/studio/src/mas-repository.js
@@ -387,7 +387,7 @@ export class MasRepository extends LitElement {
             this.operation.set();
             return new FragmentStore(fragment);
         } catch (error) {
-            if (error.message.includes('409 Conflict')) {
+            if (error.message.includes(': 409')) {
                 throw error;
             } else {
                 this.processError(error, 'Failed to create fragment.');

--- a/studio/test/mas-create-dialog.test.html
+++ b/studio/test/mas-create-dialog.test.html
@@ -66,8 +66,6 @@
                         // Fill in the form
                         const titleField =
                             dialog.shadowRoot.querySelector('#fragment-title');
-                        const nameField =
-                            dialog.shadowRoot.querySelector('#fragment-name');
 
                         // Get the dialog wrapper
                         const dialogWrapper = dialog.shadowRoot.querySelector('sp-dialog-wrapper');
@@ -79,9 +77,6 @@
                         );
 
                         await dialog.updateComplete;
-
-                        // Verify name was auto-generated
-                        expect(nameField.value).to.equal('test-merch-card');
 
                         // Submit the form by triggering the confirm event directly on dialog wrapper
                         dialogWrapper.dispatchEvent(new CustomEvent('confirm'));
@@ -101,10 +96,6 @@
                         expect(requestBody).to.have.property(
                             'title',
                             'Test Merch Card',
-                        );
-                        expect(requestBody).to.have.property(
-                            'name',
-                            'test-merch-card',
                         );
                         expect(requestBody).to.have.property('modelId');
                     });


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-170692

1. Table view now with path (2nd column) instead of fragment name 
<img width="600" alt="Screenshot 2025-05-07 at 11 10 07" src="https://github.com/user-attachments/assets/248f8257-142e-4207-8e1a-2830dfb0c3dd" />

2. When cloning a fragment, authors should be prompted to enter a new fragment title
<img width="358" alt="Screenshot 2025-05-07 at 11 11 00" src="https://github.com/user-attachments/assets/6769ff93-b1d0-4415-aa3e-1af60a178bb1" />

3. The name is removed now from the card/collection creation dialog. Name is now autogenerated from the title value. If fragment with the same path already exists the error Conflict 409 will be thrown and then fragment name will be updated with random auto-generated short string and creation will be tried again 10 more times, each time increasing the number or characters in the random string suffix. It's hard to imagine that more than 1 try will be necessary.

```
"path": "/content/dam/mas/sandbox/en_US/bozo-jovicic-card-c2b7",
"title": "Bozo Jovicic Card",
```

<img width="499" alt="Screenshot 2025-05-07 at 11 11 21" src="https://github.com/user-attachments/assets/c3fb95b0-9f9a-4c5c-9239-d489b0b7ce7b" />

For fragment cloning this suffix is added on the server side instead of throwing 409 error. For fragment creation we need to do it in our code.

Test URLs:
- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-170692--mas--adobecom.aem.live/
