### PR TITLE
Deploy to prod only via PRs, no manual trigger

### DIFF
--- a/.github/workflows/io-deploy.yaml
+++ b/.github/workflows/io-deploy.yaml
@@ -7,7 +7,6 @@ on:
       - 'io/www/**'
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   deploy-to-production:


### PR DESCRIPTION
Too unsafe to have manual trigger to deploy to prod. deploy to prod should only happen via PR merge

Test URLs:
- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-NUMBER--mas--adobecom.aem.live/
