### PR TITLE
MWPW-172853: Enable maslibs from web-components folder

### DIFF
--- a/web-components/package.json
+++ b/web-components/package.json
@@ -12,7 +12,8 @@
         "build:bundle": "node ./build.mjs",
         "build:bundle:dev": "npm run build:bundle sourcemap",
         "test:watch": "wtr --config ./web-test-runner.config.mjs --coverage --watch --debug",
-        "test": "wtr --config ./web-test-runner.config.mjs --coverage"
+        "test": "wtr --config ./web-test-runner.config.mjs --coverage",
+        "libs": "npm run build:bundle && (cd .. && aem up --port 3030)"
     },
     "devDependencies": {
         "@dexter/tacocat-core": "file:./internal/tacocat-core-1.13.1.tgz",


### PR DESCRIPTION
Enables maslibs with 'npm run libs' from /web-components folder

Resolves https://jira.corp.adobe.com/browse/MWPW-172853

QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Test URLs:
- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-172853--mas--adobecom.aem.live/
