### PR TITLE
MWPW-175397: Publishing action fix

### DIFF
--- a/studio/src/editor-panel.js
+++ b/studio/src/editor-panel.js
@@ -378,11 +378,11 @@ export default class EditorPanel extends LitElement {
     }
 
     saveFragment() {
-        this.repository.saveFragment(this.inEdit.get());
+        this.repository.saveFragment(this.fragmentStore);
     }
 
     publishFragment() {
-        this.repository.publishFragment(this.inEdit);
+        this.repository.publishFragment(this.fragment);
     }
 
     /**


### PR DESCRIPTION
Publishing was broken by my placeholder revamp PR. Basically I was passing a store to the `publishFragment` function, instead of a fragment object.

Resolves https://jira.corp.adobe.com/browse/MWPW-175397

Test URLs:
- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-175397--mas--adobecom.aem.live/
