### PR TITLE
MWPW-175385 Wide plans card not displayed as wide in studio

### DIFF
--- a/studio/merch-card.css
+++ b/studio/merch-card.css
@@ -47,26 +47,27 @@ merch-card .overlay {
     height: 100%;
 }
 
-merch-card[variant='plans'][size='wide'],
-merch-card[variant='plans-education'][size='wide'] {
+.mas-fragment merch-card[variant^='plans'][size='wide'] {
     width: 575px;
+    min-width: 575px;
 }
 
-merch-card[variant='plans'][size='super-wide'],
-merch-card[variant='plans-education'][size='super-wide'] {
+.mas-fragment merch-card[variant^='plans'][size='super-wide'] {
     width: 874px;
+    min-width: 874px;
 }
 
 @media (min-width: 926px) and (max-width: 1235px) {
-    merch-card[variant='plans'][size='super-wide'],
-    merch-card[variant='plans-education'][size='wide'] {
+    .mas-fragment merch-card[variant^='plans'][size='super-wide'] {
         width: 575px;
+        min-width: 575px;
     }
 }
 
 @media (max-width: 925px) {
-    merch-card[variant='plans'][size='super-wide'],
-    merch-card[variant='plans-education'][size='super-wide'] {
+    .mas-fragment merch-card[variant^='plans'][size='wide'],
+    .mas-fragment merch-card[variant^='plans'][size='super-wide'] {
         width: 276px;
+        min-width: 276px;
     }
 }


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-175385
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Plans wide and super-wide cards are not displayed with the right width. Their width depends on the content in the card. I fixed that by extending CSS selectors where this width is defined in MAS code. It was broken by overridden styles from Milo.

Please do the steps below before submitting your PR for a code review or QA

- [ ] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [x] C3. Verify all Checks are green (unit tests, nala tests, psi)
- [x] C4. PR description contains working Test Page link where the feature can be tested
- [x] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [x] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

Test page: `mwpw-175385--mas--adobecom.aem.live/studio.html#page=content&path=sandbox&query=cc9dc188-7513-4c39-9ec4-70a7ccc6748c`

Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-175385--mas--adobecom.aem.live/
