### PR TITLE
Nala: update plans editor test

### DIFF
--- a/nala/studio/acom/plans/individuals/tests/individuals_save.test.js
+++ b/nala/studio/acom/plans/individuals/tests/individuals_save.test.js
@@ -179,13 +179,7 @@ test.describe('M@S Studio ACOM Plans Individuals card test suite', () => {
 
         await test.step('step-4: Verify badge change is saved', async () => {
             await expect(await editor.badge).toHaveValue(data.newBadge);
-<<<<<<< HEAD
-            await expect(
-                await clonedCard.locator(individuals.cardBadge),
-            ).toHaveText(data.newBadge);
-=======
             await expect(await clonedCard.locator(individuals.cardBadge)).toHaveText(data.newBadge);
->>>>>>> upstream/main
         });
     });
 

--- a/nala/studio/studio.test.js
+++ b/nala/studio/studio.test.js
@@ -297,7 +297,7 @@ test.describe('M@S Studio feature test suite', () => {
             await expect(await editor.variant).toHaveAttribute('default-value', 'plans');
             await expect(await editor.size).toBeVisible();
             await expect(await editor.title).toBeVisible();
-            await expect(await editor.subtitle).not.toBeVisible();
+            await expect(await editor.subtitle).toBeVisible();
             await expect(await editor.badge).toBeVisible();
             await expect(await editor.badgeColor).toBeVisible();
             await expect(await editor.badgeBorderColor).toBeVisible();


### PR DESCRIPTION
subtitle field has been added to the plans editor. Updating the test

Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-111111--mas--adobecom.aem.live/
