### PR TITLE
Nala: skip invalidated test

### DIFF
--- a/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
+++ b/nala/studio/ahome/try-buy-widget/tests/try_buy_widget_edit.test.js
@@ -497,7 +497,7 @@ test.describe('M@S Studio AHome Try Buy Widget card test suite', () => {
     });
 
     // @studio-try-buy-widget-add-osi - Validate adding OSI for try-buy-widget card in mas studio
-    test(`${features[10].name},${features[10].tags}`, async ({ page, baseURL }) => {
+    test.skip(`${features[10].name},${features[10].tags}`, async ({ page, baseURL }) => {
         const { data } = features[10];
         const testPage = `${baseURL}${features[10].path}${miloLibs}${features[10].browserParams}${data.cardid}`;
         console.info('[Test Page]: ', testPage);


### PR DESCRIPTION
Resolves no jira
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

the test card has been updated in a way that invalidates the test. We need a card without OSI for this test that is not possible to create anymore. Skipping it for now and reactivate the proper version with refactoring PR.

Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-111010--mas--adobecom.aem.live/
