### PR TITLE
MWPW-190447 Activate Alpha sorting of M@S cols in Tabular view

### DIFF
--- a/studio/src/constants.js
+++ b/studio/src/constants.js
@@ -160,6 +160,7 @@ export const EDITABLE_FRAGMENT_MODEL_IDS = Object.values(TAG_MODEL_ID_MAPPING);
 // The first value in the array should be the default value
 export const SORT_COLUMNS = {
     placeholders: ['key', 'value', 'status', 'locale', 'updatedBy', 'updatedAt'],
+    content: [null, 'path', 'title', 'modifiedAt'],
 };
 
 // Variant capabilities configuration

--- a/studio/src/constants.js
+++ b/studio/src/constants.js
@@ -160,7 +160,7 @@ export const EDITABLE_FRAGMENT_MODEL_IDS = Object.values(TAG_MODEL_ID_MAPPING);
 // The first value in the array should be the default value
 export const SORT_COLUMNS = {
     placeholders: ['key', 'value', 'status', 'locale', 'updatedBy', 'updatedAt'],
-    content: [null, 'path', 'title', 'modifiedAt'],
+    content: [null, 'path', 'title'],
 };
 
 // Variant capabilities configuration

--- a/studio/src/mas-content.js
+++ b/studio/src/mas-content.js
@@ -114,29 +114,23 @@ class MasContent extends LitElement {
     }
 
     get sortedFragments() {
-        const { sortBy, sortDirection } = Store.sort.get();
         const fragments = this.fragments.value.filter((fs) => fs.get() !== null);
-        if (!sortBy) return fragments;
+        const { sortBy, sortDirection } = this.sort.value;
+        if (sortBy !== 'path') return fragments;
         return [...fragments].sort((aStore, bStore) => {
-            const a = aStore.get();
-            const b = bStore.get();
-            if (sortBy === 'path') {
-                const cmp = (a.path || '').localeCompare(b.path || '');
-                return sortDirection === 'asc' ? cmp : -cmp;
-            }
-            if (sortBy === 'title') {
-                const cmp = (a.title || '').localeCompare(b.title || '');
-                return sortDirection === 'asc' ? cmp : -cmp;
-            }
-            if (sortBy === 'modifiedAt') {
-                const aVal = a.modified?.at ? new Date(a.modified.at).getTime() : 0;
-                const bVal = b.modified?.at ? new Date(b.modified.at).getTime() : 0;
-                return sortDirection === 'asc' ? aVal - bVal : bVal - aVal;
-            }
-            return 0;
+            const cmp = (aStore.get().path || '').localeCompare(bStore.get().path || '');
+            return sortDirection === 'asc' ? cmp : -cmp;
         });
     }
 
+
+    sortIndicator(field) {
+        const { sortBy, sortDirection } = this.sort.value;
+        if (sortBy === field) {
+            return html`<span class="sort-indicator">${sortDirection === 'asc' ? html`<sp-icon-chevron-up size="s"></sp-icon-chevron-up>` : html`<sp-icon-chevron-down size="s"></sp-icon-chevron-down>`}</span>`;
+        }
+        return html`<span class="sort-indicator">—</span>`;
+    }
 
     get tableView() {
         return html`<sp-table
@@ -148,27 +142,15 @@ class MasContent extends LitElement {
         >
             <sp-table-head>
                 <sp-table-head-cell class="expand-cell"></sp-table-head-cell>
-                <sp-table-head-cell
-                    sortable
-                    class="name"
-                    sort-direction=${this.sort.value.sortBy === 'path' ? this.sort.value.sortDirection : undefined}
-                    @click=${() => this.updateSort('path')}
-                >Path</sp-table-head-cell>
-                <sp-table-head-cell
-                    sortable
-                    class="title"
-                    sort-direction=${this.sort.value.sortBy === 'title' ? this.sort.value.sortDirection : undefined}
-                    @click=${() => this.updateSort('title')}
-                >Fragment Title</sp-table-head-cell>
+                <sp-table-head-cell class="name sortable-col" @click=${() => this.updateSort('path')}>
+                    ${this.sortIndicator('path')}Path
+                </sp-table-head-cell>
+                <sp-table-head-cell class="title sortable-col" @click=${() => this.updateSort('title')}>
+                    ${this.sortIndicator('title')}Fragment Title
+                </sp-table-head-cell>
                 <sp-table-head-cell class="offer-id">Offer ID</sp-table-head-cell>
                 <sp-table-head-cell class="offer-type">Offer Type</sp-table-head-cell>
                 <sp-table-head-cell class="last-modified-by">Last Modified By</sp-table-head-cell>
-                <sp-table-head-cell
-                    sortable
-                    class="last-modified"
-                    sort-direction=${this.sort.value.sortBy === 'modifiedAt' ? this.sort.value.sortDirection : undefined}
-                    @click=${() => this.updateSort('modifiedAt')}
-                >Last Modified</sp-table-head-cell>
                 <sp-table-head-cell class="price">Price</sp-table-head-cell>
                 <sp-table-head-cell class="status">Status</sp-table-head-cell>
                 <sp-table-head-cell class="actions">Actions</sp-table-head-cell>
@@ -203,7 +185,7 @@ class MasContent extends LitElement {
                 view = this.renderView;
                 break;
             case 'table':
-                view = this.tableView;
+                view = this.loading.value && !this.firstPageLoaded.value ? nothing : this.tableView;
                 break;
             default:
                 view = this.renderView;

--- a/studio/src/mas-content.js
+++ b/studio/src/mas-content.js
@@ -25,6 +25,7 @@ class MasContent extends LitElement {
     renderMode = new StoreController(this, Store.renderMode);
     selecting = new StoreController(this, Store.selecting);
     selection = new StoreController(this, Store.selection);
+    sort = new StoreController(this, Store.sort);
 
     connectedCallback() {
         super.connectedCallback();
@@ -103,6 +104,40 @@ class MasContent extends LitElement {
         Store.selection.set(Array.from(event.target.selectedSet));
     }
 
+    updateSort(field) {
+        const current = Store.sort.get();
+        if (current.sortBy === field) {
+            Store.sort.set({ ...current, sortDirection: current.sortDirection === 'asc' ? 'desc' : 'asc' });
+        } else {
+            Store.sort.set({ sortBy: field, sortDirection: 'asc' });
+        }
+    }
+
+    get sortedFragments() {
+        const { sortBy, sortDirection } = Store.sort.get();
+        const fragments = this.fragments.value.filter((fs) => fs.get() !== null);
+        if (!sortBy) return fragments;
+        return [...fragments].sort((aStore, bStore) => {
+            const a = aStore.get();
+            const b = bStore.get();
+            if (sortBy === 'path') {
+                const cmp = (a.path || '').localeCompare(b.path || '');
+                return sortDirection === 'asc' ? cmp : -cmp;
+            }
+            if (sortBy === 'title') {
+                const cmp = (a.title || '').localeCompare(b.title || '');
+                return sortDirection === 'asc' ? cmp : -cmp;
+            }
+            if (sortBy === 'modifiedAt') {
+                const aVal = a.modified?.at ? new Date(a.modified.at).getTime() : 0;
+                const bVal = b.modified?.at ? new Date(b.modified.at).getTime() : 0;
+                return sortDirection === 'asc' ? aVal - bVal : bVal - aVal;
+            }
+            return 0;
+        });
+    }
+
+
     get tableView() {
         return html`<sp-table
             emphasized
@@ -113,19 +148,35 @@ class MasContent extends LitElement {
         >
             <sp-table-head>
                 <sp-table-head-cell class="expand-cell"></sp-table-head-cell>
-                <sp-table-head-cell sortable class="name">Path</sp-table-head-cell>
-                <sp-table-head-cell sortable class="title">Fragment Title</sp-table-head-cell>
-                <sp-table-head-cell sortable class="offer-id">Offer ID</sp-table-head-cell>
-                <sp-table-head-cell sortable class="offer-type">Offer Type</sp-table-head-cell>
-                <sp-table-head-cell sortable class="last-modified-by">Last Modified By</sp-table-head-cell>
-                <sp-table-head-cell sortable class="price">Price</sp-table-head-cell>
-                <sp-table-head-cell sortable class="status">Status</sp-table-head-cell>
+                <sp-table-head-cell
+                    sortable
+                    class="name"
+                    sort-direction=${this.sort.value.sortBy === 'path' ? this.sort.value.sortDirection : undefined}
+                    @click=${() => this.updateSort('path')}
+                >Path</sp-table-head-cell>
+                <sp-table-head-cell
+                    sortable
+                    class="title"
+                    sort-direction=${this.sort.value.sortBy === 'title' ? this.sort.value.sortDirection : undefined}
+                    @click=${() => this.updateSort('title')}
+                >Fragment Title</sp-table-head-cell>
+                <sp-table-head-cell class="offer-id">Offer ID</sp-table-head-cell>
+                <sp-table-head-cell class="offer-type">Offer Type</sp-table-head-cell>
+                <sp-table-head-cell class="last-modified-by">Last Modified By</sp-table-head-cell>
+                <sp-table-head-cell
+                    sortable
+                    class="last-modified"
+                    sort-direction=${this.sort.value.sortBy === 'modifiedAt' ? this.sort.value.sortDirection : undefined}
+                    @click=${() => this.updateSort('modifiedAt')}
+                >Last Modified</sp-table-head-cell>
+                <sp-table-head-cell class="price">Price</sp-table-head-cell>
+                <sp-table-head-cell class="status">Status</sp-table-head-cell>
                 <sp-table-head-cell class="actions">Actions</sp-table-head-cell>
                 <sp-table-head-cell class="preview">Preview</sp-table-head-cell>
             </sp-table-head>
             <sp-table-body>
                 ${repeat(
-                    this.fragments.value.filter((fragmentStore) => fragmentStore.get() !== null),
+                    this.sortedFragments,
                     (fragmentStore) => fragmentStore.get().path,
                     (fragmentStore) => html`<mas-fragment .fragmentStore=${fragmentStore} view="table"></mas-fragment>`,
                 )}

--- a/studio/src/mas-repository.js
+++ b/studio/src/mas-repository.js
@@ -107,6 +107,7 @@ export class MasRepository extends LitElement {
         this.search = new StoreController(this, Store.search);
         this.filters = new StoreController(this, Store.filters);
         this.page = new StoreController(this, Store.page);
+        this.sort = new StoreController(this, Store.sort);
         this.foldersLoaded = new StoreController(this, Store.folders.loaded);
         this.reactiveController = new ReactiveController(this, [Store.profile, Store.createdByUsers]);
         this.recentlyUpdatedLimit = new StoreController(this, Store.fragments.recentlyUpdated.limit);
@@ -250,10 +251,20 @@ export class MasRepository extends LitElement {
         const currentPath = dataStore.getMeta('path');
         const currentQuery = dataStore.getMeta('query');
         const currentLocale = dataStore.getMeta('locale');
+        const currentSort = dataStore.getMeta('sort');
         const currentData = dataStore.get();
         const locale = this.filters.value.locale;
+        const sort = Store.sort.get();
 
-        if (currentData?.length > 0 && currentPath === path && currentQuery === query && currentLocale === locale) {
+        // Only API-sorted fields affect the cache — client-side sorts (e.g. path) reuse cached data
+        const apiSortFieldMap = { title: 'title' };
+        const apiSortField = apiSortFieldMap[sort.sortBy];
+        const apiSort = apiSortField
+            ? [{ on: apiSortField, order: sort.sortDirection.toUpperCase() }]
+            : [{ on: 'modifiedOrCreated', order: 'DESC' }];
+        const apiSortKey = JSON.stringify(apiSort);
+
+        if (currentData?.length > 0 && currentPath === path && currentQuery === query && currentLocale === locale && currentSort === apiSortKey) {
             const filteredData = currentData.filter((fragmentStore) => {
                 const fragmentPath = fragmentStore?.get?.()?.path;
                 return !Fragment.isGroupedVariationPath(fragmentPath);
@@ -268,6 +279,7 @@ export class MasRepository extends LitElement {
 
         Store.fragments.list.loading.set(true);
         Store.fragments.list.firstPageLoaded.set(false);
+        dataStore.set([]);
 
         const TAG_VARIANT_PREFIX = 'mas:variant/';
 
@@ -300,7 +312,7 @@ export class MasRepository extends LitElement {
             path: `${damPath}/${this.filters.value.locale}`,
             tags,
             ...(this.page.value !== PAGE_NAMES.TRANSLATION_EDITOR && { createdBy }),
-            sort: [{ on: 'modifiedOrCreated', order: 'DESC' }],
+            sort: apiSort,
         };
 
         const publishedTagIndex = tags.indexOf(TAG_STATUS_PUBLISHED);
@@ -370,6 +382,7 @@ export class MasRepository extends LitElement {
             dataStore.setMeta('query', query);
             dataStore.setMeta('locale', locale);
             dataStore.setMeta('tags', tags);
+            dataStore.setMeta('sort', apiSortKey);
 
             this.#abortControllers.search = null;
         } catch (error) {

--- a/studio/style.css
+++ b/studio/style.css
@@ -571,6 +571,19 @@ sp-table-head-cell {
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    gap: 5px;
+
+    &.sortable-col {
+        cursor: pointer;
+
+        .sort-indicator {
+            display: inline-flex;
+            align-items: center;
+            width: 1em;
+            flex-shrink: 0;
+            color: black;
+        }
+    }
 
     &.expand-cell {
         /* padding-left: 12px;


### PR DESCRIPTION
Activate Alpha sorting of M@S cols in Tabular view

- Add sort support for Path, Fragment Title, and Last Modified columns
- Remove sortable attribute from non-sortable columns (Offer ID, Offer Type, Last Modified By, Price, Status)
- Add sort StoreController and sortedFragments getter to MasContent
- Register content sort columns in SORT_COLUMNS constant

Resolves https://jira.corp.adobe.com/browse/MWPW-190447
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [ ] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [ ] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## 🧪 Nala E2E Tests

Nala tests run automatically when you **open this PR**.

### To run Nala tests again:

1. Add the `run nala` label to this PR (in the right sidebar)
2. Tests will run automatically on the current commit
3. Any future commits will also trigger tests **as long as the label remains**

### To stop automatic Nala tests:

- Remove the `run nala` label

> **Note**: Tests only run on commits if the `run nala` label is present. Add the label whenever you need tests to run on new changes.

## Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-190447--mas--adobecom.aem.live/
