### PR TITLE
MWPW-192297 - issue with translation of a grouped variation

### DIFF
--- a/studio/src/mas-repository.js
+++ b/studio/src/mas-repository.js
@@ -1666,6 +1666,9 @@ export class MasRepository extends LitElement {
      * Resolves the parent fragment for the provided fragment path and hydrates references.
      * Finds the parent whose variations field contains fragmentPath.
      * Flow: referencedBy -> filter by variations field -> getById (hydrated)
+     * Note: localization copies the `variations` field to all locale copies, so
+     * getReferencedBy may return 30+ candidates. We sort to check the default-locale
+     * parent first since grouped variations always derive from the default locale.
      * @param {string} fragmentPath
      * @returns {Promise<Object|null>}
      */
@@ -1674,7 +1677,18 @@ export class MasRepository extends LitElement {
         const parentRefs = references?.parentReferences || [];
         if (!parentRefs.length) return null;
 
-        for (const ref of parentRefs) {
+        const surface = extractSurfaceFromPath(fragmentPath);
+        const variationLocale = extractLocaleFromPath(fragmentPath);
+        const defaultLocale = surface && variationLocale ? getDefaultLocaleCode(surface, variationLocale) : null;
+        const sortedRefs = defaultLocale
+            ? [...parentRefs].sort((a, b) => {
+                  const aIsDefault = extractLocaleFromPath(a.path) === defaultLocale ? -1 : 1;
+                  const bIsDefault = extractLocaleFromPath(b.path) === defaultLocale ? -1 : 1;
+                  return aIsDefault - bIsDefault;
+              })
+            : parentRefs;
+
+        for (const ref of sortedRefs) {
             const candidate = await this.aem.sites.cf.fragments.getByPath(ref.path);
             if (!candidate) continue;
 

--- a/studio/test/mas-repository.test.js
+++ b/studio/test/mas-repository.test.js
@@ -2069,6 +2069,54 @@ describe('MasRepository dictionary helpers', () => {
             expect(result).to.be.null;
             expect(repository.aem.sites.cf.fragments.getById.called).to.be.false;
         });
+
+        it('prefers default-locale parent when locale copies also have the variation in their variations field', async () => {
+            const repository = createRepository();
+            const sourcePath =
+                '/content/dam/mas/sandbox/en_US/pac/pzn/grouped-source';
+            const koKrParentPath =
+                '/content/dam/mas/sandbox/ko_KR/pac/default-fragment';
+            const enUsParentPath =
+                '/content/dam/mas/sandbox/en_US/pac/default-fragment';
+
+            const koKrParent = {
+                id: 'ko-kr-id',
+                path: koKrParentPath,
+                fields: [{ name: 'variations', values: [sourcePath] }],
+            };
+            const enUsParent = {
+                id: 'en-us-id',
+                path: enUsParentPath,
+                fields: [{ name: 'variations', values: [sourcePath] }],
+            };
+            const hydratedEnUsParent = { ...enUsParent, references: [] };
+
+            const getByPathStub = sandbox.stub();
+            getByPathStub.withArgs(koKrParentPath).resolves(koKrParent);
+            getByPathStub.withArgs(enUsParentPath).resolves(enUsParent);
+
+            repository.aem = createAemMock({
+                fragments: {
+                    // ko_KR comes first in AEM's response order — this is the bug scenario
+                    getReferencedBy: sandbox.stub().resolves({
+                        path: sourcePath,
+                        parentReferences: [
+                            { type: 'content-fragment', path: koKrParentPath },
+                            { type: 'content-fragment', path: enUsParentPath },
+                        ],
+                    }),
+                    getByPath: getByPathStub,
+                    getById: sandbox.stub().resolves(hydratedEnUsParent),
+                },
+            });
+
+            const result = await repository.resolveHydratedParentFragment(sourcePath);
+
+            // Must return the en_US parent, not the ko_KR one
+            expect(repository.aem.sites.cf.fragments.getById.calledOnceWith('en-us-id')).to.be
+                .true;
+            expect(result).to.deep.equal(hydratedEnUsParent);
+        });
     });
 
     describe('createGroupedVariation', () => {

--- a/studio/test/mas-repository.test.js
+++ b/studio/test/mas-repository.test.js
@@ -2072,12 +2072,9 @@ describe('MasRepository dictionary helpers', () => {
 
         it('prefers default-locale parent when locale copies also have the variation in their variations field', async () => {
             const repository = createRepository();
-            const sourcePath =
-                '/content/dam/mas/sandbox/en_US/pac/pzn/grouped-source';
-            const koKrParentPath =
-                '/content/dam/mas/sandbox/ko_KR/pac/default-fragment';
-            const enUsParentPath =
-                '/content/dam/mas/sandbox/en_US/pac/default-fragment';
+            const sourcePath = '/content/dam/mas/sandbox/en_US/pac/pzn/grouped-source';
+            const koKrParentPath = '/content/dam/mas/sandbox/ko_KR/pac/default-fragment';
+            const enUsParentPath = '/content/dam/mas/sandbox/en_US/pac/default-fragment';
 
             const koKrParent = {
                 id: 'ko-kr-id',
@@ -2113,8 +2110,7 @@ describe('MasRepository dictionary helpers', () => {
             const result = await repository.resolveHydratedParentFragment(sourcePath);
 
             // Must return the en_US parent, not the ko_KR one
-            expect(repository.aem.sites.cf.fragments.getById.calledOnceWith('en-us-id')).to.be
-                .true;
+            expect(repository.aem.sites.cf.fragments.getById.calledOnceWith('en-us-id')).to.be.true;
             expect(result).to.deep.equal(hydratedEnUsParent);
         });
     });


### PR DESCRIPTION
- `resolveHydratedParentFragment` now sorts `parentRefs` to put the default-locale (en_US) candidate first before iterating, so the US parent is always preferred over locale copies that inherited the `variations` field from loc
- new test case covers the exact production scenario: `ko_KR` copy comes first in AEM's response, but the function correctly returns the `en_US` parent

Resolves https://jira.corp.adobe.com/browse/MWPW-192297
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [x] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [ ] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## 🧪 Nala E2E Tests

Nala tests run automatically when you **open this PR**.

### To run Nala tests again:

1. Add the `run nala` label to this PR (in the right sidebar)
2. Tests will run automatically on the current commit
3. Any future commits will also trigger tests **as long as the label remains**

### To stop automatic Nala tests:

- Remove the `run nala` label

> **Note**: Tests only run on commits if the `run nala` label is present. Add the label whenever you need tests to run on new changes.

## Test URLs:

- Before: https://mas.adobe.com/studio.html#fragmentId=98c201e1-09bd-45ae-94e3-d1cca1a197a3&page=fragment-editor&path=acom&tags=mas%3Avariant%2Fmini-compare-chart-mweb
- After: https://mwpw-192297--mas--adobecom.aem.live/studio.html#fragmentId=98c201e1-09bd-45ae-94e3-d1cca1a197a3&page=fragment-editor&path=acom&tags=mas%3Avariant%2Fmini-compare-chart-mweb
