### PR TITLE
[MWPW-191170] - Remove auto-applied "Created By" filter in Sandbox

### DIFF
--- a/nala/studio/studio.page.js
+++ b/nala/studio/studio.page.js
@@ -18,7 +18,6 @@ export default class StudioPage {
         this.filter = page.locator('sp-action-button[label="Filter"]');
         this.filterPanel = page.locator('mas-filter-panel');
         this.createdByTag = this.filterPanel.locator('sp-tag sp-icon-user');
-        this.filterCountBadge = this.filter.locator('sp-badge, [slot="badge"]');
         this.folderPicker = page.locator('mas-nav-folder-picker sp-action-menu');
         this.previewMenu = page.locator('#actions sp-action-menu[value="render"]');
         this.renderViewOption = this.previewMenu.locator('sp-menu-item[value="render"]');

--- a/nala/studio/studio.page.js
+++ b/nala/studio/studio.page.js
@@ -16,6 +16,9 @@ export default class StudioPage {
         this.searchInput = page.locator('#actions sp-search  input');
         this.searchIcon = page.locator('#actions sp-search[placeholder="Search"] sp-icon-search');
         this.filter = page.locator('sp-action-button[label="Filter"]');
+        this.filterPanel = page.locator('mas-filter-panel');
+        this.createdByTag = this.filterPanel.locator('sp-tag sp-icon-user');
+        this.filterCountBadge = this.filter.locator('sp-badge, [slot="badge"]');
         this.folderPicker = page.locator('mas-nav-folder-picker sp-action-menu');
         this.previewMenu = page.locator('#actions sp-action-menu[value="render"]');
         this.renderViewOption = this.previewMenu.locator('sp-menu-item[value="render"]');

--- a/nala/studio/studio.spec.js
+++ b/nala/studio/studio.spec.js
@@ -133,5 +133,12 @@ export default {
             },
             tags: '@mas-studio @regional-variations @grouped-variations',
         },
+        {
+            tcid: '14',
+            name: '@studio-sandbox-no-created-by-filter',
+            path: '/studio.html',
+            browserParams: '#page=welcome&path=sandbox',
+            tags: '@mas-studio',
+        },
     ],
 };

--- a/nala/studio/studio.spec.js
+++ b/nala/studio/studio.spec.js
@@ -137,7 +137,7 @@ export default {
             tcid: '14',
             name: '@studio-sandbox-no-created-by-filter',
             path: '/studio.html',
-            browserParams: '#page=welcome&path=sandbox',
+            browserParams: '#page=content&path=sandbox',
             tags: '@mas-studio',
         },
     ],

--- a/nala/studio/studio.test.js
+++ b/nala/studio/studio.test.js
@@ -461,4 +461,26 @@ test.describe('M@S Studio feature test suite', () => {
             });
         });
     });
+
+    // @studio-sandbox-no-created-by-filter - Validate Sandbox does not auto-apply a Created By filter
+    test(`${features[14].name},${features[14].tags}`, async ({ page, baseURL }) => {
+        const testPage = `${baseURL}${features[14].path}${miloLibs}${features[14].browserParams}`;
+        setTestPage(testPage);
+
+        await test.step('step-1: Go to MAS Studio sandbox page', async () => {
+            await page.goto(testPage);
+            await page.waitForLoadState('domcontentloaded');
+        });
+
+        await test.step('step-2: Validate sandbox surface is selected', async () => {
+            await expect(await studio.surfacePicker).toHaveAttribute('value', 'sandbox');
+        });
+
+        await test.step('step-3: Validate no Created By filter is auto-applied', async () => {
+            await studio.waitForCardsLoaded();
+            await expect(studio.createdByTag).toHaveCount(0);
+            const cards = studio.renderView.locator('merch-card');
+            expect(await cards.count()).toBeGreaterThan(1);
+        });
+    });
 });

--- a/nala/studio/studio.test.js
+++ b/nala/studio/studio.test.js
@@ -473,14 +473,13 @@ test.describe('M@S Studio feature test suite', () => {
         });
 
         await test.step('step-2: Validate sandbox surface is selected', async () => {
-            await expect(await studio.surfacePicker).toHaveAttribute('value', 'sandbox');
+            await expect(studio.surfacePicker).toHaveAttribute('value', 'sandbox');
         });
 
         await test.step('step-3: Validate no Created By filter is auto-applied', async () => {
             await studio.waitForCardsLoaded();
             await expect(studio.createdByTag).toHaveCount(0);
-            const cards = studio.renderView.locator('merch-card');
-            expect(await cards.count()).toBeGreaterThan(1);
+            await expect(studio.renderView.locator('merch-card').nth(1)).toBeVisible();
         });
     });
 });

--- a/studio/src/users.js
+++ b/studio/src/users.js
@@ -28,7 +28,7 @@ export async function initUsers() {
         const uniqueEditors = await loadUsers();
         Store.users.set(uniqueEditors);
 
-        Store.search.subscribe(async () => {
+        Store.search.subscribe(() => {
             Store.createdByUsers.set([]);
         });
     } catch (e) {

--- a/studio/src/users.js
+++ b/studio/src/users.js
@@ -28,17 +28,8 @@ export async function initUsers() {
         const uniqueEditors = await loadUsers();
         Store.users.set(uniqueEditors);
 
-        Store.search.subscribe(async ({ path }) => {
-            if (path === 'sandbox') {
-                Store.createdByUsers.set([
-                    {
-                        displayName: profile.displayName,
-                        userPrincipalName: profile.email,
-                    },
-                ]);
-            } else {
-                Store.createdByUsers.set([]);
-            }
+        Store.search.subscribe(async () => {
+            Store.createdByUsers.set([]);
         });
     } catch (e) {
         console.error('Error initializing users', e);


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/MWPW-191170

## Summary
- Remove the automatic `createdByUsers` filter applied when navigating to the Sandbox surface in Studio's Fragment view
- Sandbox now loads with no filters pre-applied, consistent with all other surfaces
- Authors can still manually add a "Created By" filter after landing

## Test URLs:

- Before: https://main--mas--adobecom.aem.page/studio.html#page=welcome&path=sandbox
- After: https://mwpw-191170--mas--adobecom.aem.page/studio.html#page=welcome&path=sandbox


[Pinata PR](https://github.com/adobecom/mas-pinata/pull/276)