### PR TITLE
MWPW-193794: fix grouped vars

### DIFF
--- a/io/www/src/fragment/transformers/customize.js
+++ b/io/www/src/fragment/transformers/customize.js
@@ -97,8 +97,10 @@ function personalizationMatchScore(pznTags, { regionLocale, country, pzn }) {
     const tokens = parsePznTokens(pzn);
     const matchedTokens = countMatchedPznTokens(tags, tokens);
     const regionMatch = Boolean(regionLocale && tags.some((tag) => tag.includes(regionLocale)));
+    const effectiveCountry = country || regionLocale?.split('_')[1];
     const countryMatch = Boolean(
-        country && tags.some((tag) => tag.toLowerCase().endsWith(`pzn/country/${String(country).toLowerCase()}`)),
+        effectiveCountry &&
+            tags.some((tag) => tag.toLowerCase().endsWith(`pzn/country/${String(effectiveCountry).toLowerCase()}`)),
     );
     if (matchedTokens === 0 && !regionMatch && !countryMatch) {
         return 0;

--- a/io/www/test/fragment/customize.test.js
+++ b/io/www/test/fragment/customize.test.js
@@ -219,6 +219,46 @@ describe('customize collections', function () {
         expect(result.body.fields.badge).to.equal('Kuwait country PZN');
     });
 
+    it('should merge personalization using country implied by locale when country param is absent', async function () {
+        const pznVariationId = 'pzn-var-br-locale-implied';
+        const bodyWithPzn = {
+            path: '/content/dam/mas/express/pt_BR/pzn-test-fragment',
+            id: 'root-fragment',
+            title: 'Root',
+            fields: {
+                badge: 'default badge',
+                variations: [pznVariationId],
+            },
+            references: {
+                [pznVariationId]: {
+                    type: 'content-fragment',
+                    value: {
+                        path: '/content/dam/mas/express/pt_BR/PA-484/pzn/individual-edu-country-br',
+                        id: pznVariationId,
+                        title: 'Brazil country targeting',
+                        fields: {
+                            pznTags: ['experience-fragments:mas/express/pzn/country/br'],
+                            badge: 'Brazil country PZN',
+                        },
+                    },
+                },
+            },
+            referencesTree: [],
+        };
+
+        const result = await process({
+            ...FAKE_CONTEXT,
+            surface: 'express',
+            fragmentPath: 'pzn-test-fragment',
+            locale: 'pt_BR',
+            parsedLocale: 'pt_BR',
+            body: bodyWithPzn,
+        });
+
+        expect(result.status).to.equal(200);
+        expect(result.body.fields.badge).to.equal('Brazil country PZN');
+    });
+
     it('should merge personalization when country is MX and pznTags end with pzn/country/MX', async function () {
         const pznVariationId = 'pzn-var-mx';
         const bodyWithPzn = {


### PR DESCRIPTION
fix for grouped vars.  reproducible only on aem.live and www.adobe.com
grouped vars are not applied if ?country param is missing. change to vars apply if correct country is given in locale param.
### example
 [prod](https://www.adobe.com/mas/io/fragment?id=27e8092f-330b-43f7-bdef-aeb386482d3c&api_key=AdobeExpressWeb&locale=pt_BR&country=BR) returns variation
[prod without country](https://www.adobe.com/mas/io/fragment?id=27e8092f-330b-43f7-bdef-aeb386482d3c&api_key=AdobeExpressWeb&locale=pt_BR) returns default

### Test links
- Before: https://main--da-express-milo--adobecom.aem.live/br/express/pricing
- After: https://main--da-express-milo--adobecom.aem.live/br/express/pricing?mas-io-url=https://14257-merchatscale-3ch023.adobeioruntime.net/api/v1/web/MerchAtScale


Colombia was working before because there country is different from default language country (es_ES):
https://main--da-express-milo--adobecom.aem.live/es/express/pricing?country=co&mas-io-url=https://14257-merchatscale-3ch023.adobeioruntime.net/api/v1/web/MerchAtScale
leaving link here just to validate that no regressions happened

