### PR TITLE
MWPW-194174: Stabilize Nala against EDS rate limits

### DIFF
--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -91,6 +91,9 @@ jobs:
                   IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
                   IMS_PASS: ${{ secrets.IMS_PASS }}
                   FORCE_COLOR: 3 # Force color output
+                  # 4 workers × 45 RPS/worker = 180 RPS combined, safely under the 200 RPS
+                  # per-hostname limit enforced by AEM.live. Raise only if EDS grants a higher cap.
+                  NALA_PLAYWRIGHT_WORKERS: 4
 
             - name: Cleanup cloned cards
               if: always()

--- a/nala/libs/auth.setup.cjs
+++ b/nala/libs/auth.setup.cjs
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-import-module-exports */
 import { test as setup, expect } from '@playwright/test';
 import path from 'path';
+import { installEdsThrottleOnPage } from './eds-throttle.js';
 
 const authFile = path.join(__dirname, '../../nala/.auth/user.json');
 
@@ -14,6 +15,7 @@ setup('authenticate, @mas-studio', async ({ page, baseURL, browserName }) => {
     expect(process.env.IMS_EMAIL, 'ERROR: No environment variable for email provided for IMS Test.').toBeTruthy();
     expect(process.env.IMS_PASS, 'ERROR: No environment variable for password provided for IMS Test.').toBeTruthy();
 
+    await installEdsThrottleOnPage(page);
     await page.goto(`${baseURL}/studio.html`);
     await page.waitForURL('**/auth.services.adobe.com/en_US/index.html**/');
 

--- a/nala/libs/eds-throttle.js
+++ b/nala/libs/eds-throttle.js
@@ -1,0 +1,85 @@
+/**
+ * Pace requests to EDS / Helix preview hosts (~200 rps tenant limit).
+ *
+ * Throttle state is per Playwright *worker process*. Multiple workers each run their own chain,
+ * so effective RPS to the same hostname is multiplied — use workers=1 on CI (see playwright.config.js).
+ *
+ * Auth setup loads studio.html before GlobalRequestCounter runs; call installEdsThrottleOnPage(page)
+ * there so the first navigation is paced too.
+ */
+
+/** Default CI cap under 200 rps with headroom for edge burst rules. */
+const DEFAULT_CI_EDS_MAX_RPS = 45;
+
+export function resolveEdsMaxRps() {
+    if (process.env.NALA_EDS_THROTTLE_DISABLED === '1') return 0;
+    if (process.env.NALA_EDS_MAX_RPS !== undefined && process.env.NALA_EDS_MAX_RPS !== '') {
+        const v = Number.parseInt(process.env.NALA_EDS_MAX_RPS, 10);
+        return Number.isFinite(v) && v > 0 ? v : 0;
+    }
+    return process.env.CI === 'true' ? DEFAULT_CI_EDS_MAX_RPS : 0;
+}
+
+export function isEdsEdgeHost(url) {
+    try {
+        const { hostname } = new URL(url);
+        return (
+            hostname.endsWith('.aem.live') ||
+            hostname.endsWith('.hlx.page') ||
+            hostname.endsWith('.hlx.live') ||
+            hostname === 'aem.live'
+        );
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Serialize route.continue() for EDS hosts with a minimum gap (per worker).
+ * @param {number} maxRps
+ */
+export function throttleEdsGap(maxRps) {
+    const minGapMs = 1000 / maxRps;
+    if (!globalThis._edsThrottleChain) {
+        globalThis._edsThrottleChain = Promise.resolve();
+    }
+
+    const next = globalThis._edsThrottleChain.then(async () => {
+        const last = globalThis._edsThrottleLastContinueAt ?? 0;
+        const now = Date.now();
+        const wait = Math.max(0, minGapMs - (now - last));
+        if (wait > 0) {
+            await new Promise((r) => setTimeout(r, wait));
+        }
+        globalThis._edsThrottleLastContinueAt = Date.now();
+    });
+
+    globalThis._edsThrottleChain = next.catch(() => {});
+    return next;
+}
+
+export function logEdsThrottleOnce(edsMaxRps) {
+    if (edsMaxRps <= 0 || globalThis._edsThrottleLogged) return;
+    globalThis._edsThrottleLogged = true;
+    console.info(
+        `[NALA] EDS request pacing ~${edsMaxRps} rps per worker for .aem.live / hlx hosts. ` +
+            `NALA_EDS_THROTTLE_DISABLED=1 disables; NALA_EDS_MAX_RPS sets cap. Use one Playwright worker on CI so pacing is not multiplied.\n`,
+    );
+}
+
+/**
+ * Register a route handler that paces EDS-bound requests (auth / any page without GlobalRequestCounter).
+ * @param {import('@playwright/test').Page} page
+ */
+export async function installEdsThrottleOnPage(page) {
+    const edsMaxRps = resolveEdsMaxRps();
+    if (edsMaxRps <= 0) return;
+    logEdsThrottleOnce(edsMaxRps);
+    await page.route('**/*', async (route) => {
+        const url = route.request().url();
+        if (isEdsEdgeHost(url)) {
+            await throttleEdsGap(edsMaxRps);
+        }
+        await route.continue();
+    });
+}

--- a/nala/libs/global-request-counter.js
+++ b/nala/libs/global-request-counter.js
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { resolveEdsMaxRps, isEdsEdgeHost, throttleEdsGap, logEdsThrottleOnce } from './eds-throttle.js';
 
 const DEFAULT_TRACKED_URLS = {
     ODIN_AEM: 'https://author-p22655-e59433.adobeaemcloud.com',
@@ -49,6 +50,9 @@ class GlobalRequestCounter {
             };
         }
 
+        const edsMaxRps = resolveEdsMaxRps();
+        logEdsThrottleOnce(edsMaxRps);
+
         // Set up routing to track requests to all configured URLs
         await page.route('**/*', async (route) => {
             const url = route.request().url();
@@ -62,6 +66,10 @@ class GlobalRequestCounter {
                     serviceCount.methods[method] = (serviceCount.methods[method] || 0) + 1;
                     break; // Only count for the first matching service
                 }
+            }
+
+            if (edsMaxRps > 0 && isEdsEdgeHost(url)) {
+                await throttleEdsGap(edsMaxRps);
             }
 
             await route.continue();

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -28,8 +28,16 @@ const config = {
     forbidOnly: !!process.env.CI,
     /* Retry on CI only */
     retries: process.env.CI ? 1 : 0,
-    /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 4 : 3,
+    /*
+     * EDS (~200 rps / hostname). EDS pacing in nala/libs/eds-throttle.js is per *worker*; multiple
+     * workers multiply traffic to the same preview host → 429s. Default CI workers=1; override
+     * with NALA_PLAYWRIGHT_WORKERS only if EDS grants a higher automation cap.
+     */
+    workers: (() => {
+        const fromEnv = Number.parseInt(process.env.NALA_PLAYWRIGHT_WORKERS ?? '', 10);
+        if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
+        return process.env.CI ? 1 : 3;
+    })(),
     /* Reporter to use. */
     reporter: process.env.CI
         ? [['github'], ['list'], ['./nala/utils/base-reporter.js']]
@@ -78,7 +86,11 @@ const config = {
             },
             bypassCSP: true,
             launchOptions: {
-                args: ['--disable-web-security', '--disable-gpu'],
+                // --disable-http2 forces HTTP/1.1, capping concurrent connections at 6 per
+                // origin. This prevents the browser from multiplexing all ~150 studio JS
+                // module requests simultaneously over HTTP/2, which would burst past the
+                // 200 RPS per-hostname limit now enforced by AEM.live on feature branches.
+                args: ['--disable-web-security', '--disable-gpu', '--disable-http2'],
             },
             dependencies: ['setup'],
             testMatch: /nala\/studio\/.*\.test\.js/,


### PR DESCRIPTION
EDS is enforcing the limit of 200 rps per host ([thread](https://adobe-mwp.slack.com/archives/C05QU7MMRNF/p1777482269801729)). This has caused 429 errors and failing Nala on all PRs.

We are introducing the limit of 45 rpc per worker (Number of workers set is 4), keeping the parallel execution below the limit and approx. the same duration.

Resolves https://jira.corp.adobe.com/browse/MWPW-194174
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [ ] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [ ] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## 🧪 Nala E2E Tests

Nala tests run automatically when you **open this PR**.

### To run Nala tests again:

1. Add the `run nala` label to this PR (in the right sidebar)
2. Tests will run automatically on the current commit
3. Any future commits will also trigger tests **as long as the label remains**

### To stop automatic Nala tests:

- Remove the `run nala` label

> **Note**: Tests only run on commits if the `run nala` label is present. Add the label whenever you need tests to run on new changes.

## Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-194174--mas--adobecom.aem.live/
