### PR TITLE
MWPW-195154 Show template-scoped overrides when templates match the top-level setting

### DIFF
--- a/studio/src/settings/settings-store.js
+++ b/studio/src/settings/settings-store.js
@@ -122,16 +122,6 @@ const resolveValueType = (settingName, ...fallbacks) => {
 const resolveBooleanValue = (valueType, value, booleanValue) =>
     valueType === 'boolean' ? Boolean(value) : Boolean(booleanValue);
 
-const normalizedStringList = (values = []) =>
-    [...new Set(values.map((value) => `${value}`.trim()).filter((value) => value))].sort();
-
-const areStringListsEqual = (left = [], right = []) => {
-    const leftList = normalizedStringList(left);
-    const rightList = normalizedStringList(right);
-    if (leftList.length !== rightList.length) return false;
-    return leftList.every((value, index) => value === rightList[index]);
-};
-
 const templateSummaryHelper = createTreeSelectionSummary(getVariantTreeData());
 
 const getRowRecord = (rowLike) => (rowLike?.value?.name ? rowLike.value : rowLike);
@@ -1014,9 +1004,7 @@ export class SettingsStore {
                     topLevelByName.set(record.name, fragment);
                     continue;
                 }
-
-                const retainedTopLevel = normalizeSettingFragment(topLevelByName.get(record.name));
-                if (areStringListsEqual(record.templateIds, retainedTopLevel.templateIds)) continue;
+                if (record.templateIds.length === 0) continue;
             }
 
             const nestedNameKey = fieldName === INDEX_REFERENCES_FIELD ? record.name : fieldName;

--- a/studio/test/settings/settings-store.test.js
+++ b/studio/test/settings/settings-store.test.js
@@ -749,6 +749,48 @@ describe('Settings Store Namespace', () => {
         expect(rows[0].overrides.map((override) => override.id)).to.deep.equal(['setting-quantity-select-fr']);
     });
 
+    it('keeps a template-scoped override when its templates match the top-level templates', async () => {
+        const topLevel = createSettingReference({
+            id: 'setting-show-plan-type-top',
+            name: 'showPlanType',
+            label: 'Show plan type',
+            locales: [],
+            templates: ['catalog'],
+            path: '/content/dam/mas/sandbox/settings/showplantype-all-catalog',
+        });
+        const templateOverride = createSettingReference({
+            id: 'setting-show-plan-type-override',
+            name: 'showPlanType',
+            label: 'Show plan type override',
+            locales: [],
+            templates: ['catalog'],
+            path: '/content/dam/mas/sandbox/settings/showplantype-all-catalog-xyz',
+        });
+
+        const store = new SettingsStore();
+        store.setAem({
+            sites: {
+                cf: {
+                    fragments: {
+                        getByPath: async () => ({
+                            id: 'settings-index',
+                            path: '/content/dam/mas/sandbox/settings/index',
+                            fields: [{ name: 'entries', values: [topLevel.path, templateOverride.path] }],
+                            references: [topLevel, templateOverride],
+                        }),
+                    },
+                },
+            },
+        });
+
+        await store.loadSurface('sandbox');
+
+        const rows = store.rows.get().map((rowStore) => rowStore.value);
+        expect(rows.length).to.equal(1);
+        expect(rows[0].id).to.equal('setting-show-plan-type-top');
+        expect(rows[0].overrides.map((override) => override.id)).to.deep.equal(['setting-show-plan-type-override']);
+    });
+
     it('does not delete top-level settings', async () => {
         const topLevel = createSettingReference({
             id: 'setting-show-plan-type',


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-195154
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [x] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [ ] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## Summary

When a top-level setting has a non-empty template set, an override sharing the same `templateIds` (no locales, template-scoped) was silently dropped during index parsing in `#setRowsFromIndex`. The user could create such an override via the dialog, see a success toast, and then see nothing in the table.

The dedup branch in `studio/src/settings/settings-store.js` previously skipped any secondary no-locale fragment whose templates matched the top-level. That dedup is now narrowed to only apply when the candidate has **no** templates — i.e. a true duplicate top-level shape. Template-scoped overrides now fall through and are rendered nested under their top-level row.

The unused `normalizedStringList` / `areStringListsEqual` helpers were removed.

## 🧪 Nala E2E Tests

Nala tests run automatically when you **open this PR**.

### To run Nala tests again:

1. Add the `run nala` label to this PR (in the right sidebar)
2. Tests will run automatically on the current commit
3. Any future commits will also trigger tests **as long as the label remains**

### To stop automatic Nala tests:

- Remove the `run nala` label

> **Note**: Tests only run on commits if the `run nala` label is present. Add the label whenever you need tests to run on new changes.

## Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-195154--mas--adobecom.aem.live/

## Test plan

- [x] Unit test added: `studio/test/settings/settings-store.test.js` — "keeps a template-scoped override when its templates match the top-level templates"
- [x] Full settings test suite passes (`settings-store.test.js`, `mas-settings.test.html`, `mas-settings-table.test.html` — 71 tests)
- [ ] Manual: in MAS Studio settings page, create a top-level setting scoped to template X; add a template-scoped override on the same template X (no locale); reload — override row should now appear nested under the top-level.