### PR TITLE
MWPW-195237 fixed variation of nested collections

### DIFF
--- a/io/www/src/fragment/transformers/customize.js
+++ b/io/www/src/fragment/transformers/customize.js
@@ -225,15 +225,24 @@ function customizeTree(root, referencesTree = [], customizeContext) {
     const adaptedTree = adaptReferencesTree(referencesTree, customizedRoot);
 
     //now we look into referenced fragments to customize them as well
-    for (const reference of adaptedTree) {
+    for (let i = 0; i < adaptedTree.length; i++) {
+        const reference = adaptedTree[i];
         //customize each card/collection
         if (reference.fieldName === 'cards' || reference.fieldName === 'collections') {
             const child = customizeContext.references[reference.identifier]?.value;
             if (child) {
                 //start customization of the child fragment
-                const { references: customizedReferences } = customizeTree(child, reference.referencesTree, customizeContext);
+                const { references: customizedReferences, referencesTree: childAdaptedTree } = customizeTree(
+                    child,
+                    reference.referencesTree,
+                    customizeContext,
+                );
                 //we collect update references and merge in current references
                 customizeContext.references = { ...customizeContext.references, ...customizedReferences };
+                //propagate adapted child tree up so the parent's tree stays in sync with the customized child fields
+                if (childAdaptedTree !== reference.referencesTree) {
+                    adaptedTree[i] = { ...reference, referencesTree: childAdaptedTree };
+                }
             }
         }
     }

--- a/io/www/test/fragment/customize.test.js
+++ b/io/www/test/fragment/customize.test.js
@@ -834,6 +834,96 @@ describe('customize collections', function () {
         expect(cardEntries[1].referencesTree).to.deep.equal([]);
     });
 
+    it('should propagate adapted referencesTree of a child collection up to the parent', async function () {
+        // Parent collection has no variation. Child subcollection has a pzn variation that swaps the last card.
+        // Without propagation, the parent's referencesTree[subcoll].referencesTree still lists the base cards,
+        // while references[subcoll].value.fields.cards lists the variation cards — causing renderers to mismatch.
+        const body = {
+            path: '/content/dam/mas/sandbox/en_US/root-coll',
+            id: 'root-coll',
+            title: 'Root',
+            fields: {
+                cards: [],
+                collections: ['subcoll'],
+                variations: [],
+            },
+            references: {
+                subcoll: {
+                    type: 'content-fragment',
+                    value: {
+                        path: '/content/dam/mas/sandbox/en_US/subcoll',
+                        id: 'subcoll',
+                        fields: {
+                            cards: ['card-a', 'card-base-last'],
+                            collections: [],
+                            variations: ['subcoll-pzn'],
+                        },
+                    },
+                },
+                'subcoll-pzn': {
+                    type: 'content-fragment',
+                    value: {
+                        path: '/content/dam/mas/sandbox/en_US/PA-1/pzn/subcoll-en-us',
+                        id: 'subcoll-pzn',
+                        fields: {
+                            pznTags: ['mas:locale/en_US'],
+                            cards: ['card-a', 'card-pzn-last'],
+                        },
+                    },
+                },
+                'card-a': {
+                    type: 'content-fragment',
+                    value: { path: '/content/dam/mas/sandbox/en_US/card-a', id: 'card-a', fields: { variations: [] } },
+                },
+                'card-base-last': {
+                    type: 'content-fragment',
+                    value: {
+                        path: '/content/dam/mas/sandbox/en_US/card-base-last',
+                        id: 'card-base-last',
+                        fields: { variations: [] },
+                    },
+                },
+                'card-pzn-last': {
+                    type: 'content-fragment',
+                    value: {
+                        path: '/content/dam/mas/sandbox/en_US/card-pzn-last',
+                        id: 'card-pzn-last',
+                        fields: { variations: [] },
+                    },
+                },
+            },
+            referencesTree: [
+                {
+                    fieldName: 'collections',
+                    identifier: 'subcoll',
+                    referencesTree: [
+                        { fieldName: 'cards', identifier: 'card-a', referencesTree: [] },
+                        { fieldName: 'cards', identifier: 'card-base-last', referencesTree: [] },
+                        { fieldName: 'variations', identifier: 'subcoll-pzn', referencesTree: [] },
+                    ],
+                },
+            ],
+        };
+
+        const result = await process({
+            ...FAKE_CONTEXT,
+            fragmentPath: 'root-coll',
+            locale: 'en_US',
+            parsedLocale: 'en_US',
+            body,
+        });
+
+        expect(result.status).to.equal(200);
+
+        // sanity: subcoll value in references has the pzn cards
+        expect(result.body.references.subcoll.value.fields.cards).to.deep.equal(['card-a', 'card-pzn-last']);
+
+        // the parent's referencesTree[subcoll].referencesTree must reflect the pzn cards, NOT the base ones
+        const subcollEntry = result.body.referencesTree.find((e) => e.identifier === 'subcoll');
+        const subcollCardIds = subcollEntry.referencesTree.filter((e) => e.fieldName === 'cards').map((e) => e.identifier);
+        expect(subcollCardIds).to.deep.equal(['card-a', 'card-pzn-last']);
+    });
+
     it('should not merge personalization variation when no pznTags match regionLocale', async function () {
         const pznVariationId = 'pzn-var-other';
         const bodyWithPzn = {


### PR DESCRIPTION
updating reference tree that is used directly in merch-card-collection to build up the sidenav & subcollection

Resolves https://jira.corp.adobe.com/browse/MWPW-195237
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [x] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [x] C4. PR description contains working Test Page link where the feature can be tested
- [x] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [x] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## Test URLs:
### Preview
- non regression & **fix** on us plans page https://main--cc--adobecom.aem.page/creativecloud/plans?maslibs=MWPW-195237
- non regression on fr plans page https://main--cc--adobecom.aem.page/fr/creativecloud/plans?maslibs=MWPW-195237
- non regression on catalog page https://main--cc--adobecom.aem.page/products/catalog?maslibs=MWPW-195237
### mas/io
- non regression on us plans page https://main--cc--adobecom.aem.live/creativecloud/plans?mas-io-url=https://14257-merchatscale-npeltier.adobeioruntime.net/api/v1/web/MerchAtScale
- non regression on fr plans page https://main--cc--adobecom.aem.live/fr/creativecloud/plans?mas-io-url=https://14257-merchatscale-npeltier.adobeioruntime.net/api/v1/web/MerchAtScale
- non regression on catalog page https://main--cc--adobecom.aem.page/products/catalog?mas-io-url=https://14257-merchatscale-npeltier.adobeioruntime.net/api/v1/web/MerchAtScale