### PR TITLE
fix(mini-compare-chart-mweb): align OST badge percentage

### DIFF
--- a/web-components/dist/mas.js
+++ b/web-components/dist/mas.js
@@ -2630,6 +2630,9 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     inset-inline-end: 0;
     line-height: 16px;
   }
+  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span{
+    min-height: auto;
+  }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {
     left: 0;

--- a/web-components/dist/mas.js
+++ b/web-components/dist/mas.js
@@ -2630,7 +2630,8 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     inset-inline-end: 0;
     line-height: 16px;
   }
-  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span{
+
+  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
     min-height: auto;
   }
 

--- a/web-components/dist/merch-card-collection.js
+++ b/web-components/dist/merch-card-collection.js
@@ -1515,6 +1515,9 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     inset-inline-end: 0;
     line-height: 16px;
   }
+  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span{
+    min-height: auto;
+  }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {
     left: 0;

--- a/web-components/dist/merch-card-collection.js
+++ b/web-components/dist/merch-card-collection.js
@@ -1515,7 +1515,8 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     inset-inline-end: 0;
     line-height: 16px;
   }
-  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span{
+
+  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
     min-height: auto;
   }
 

--- a/web-components/dist/merch-card.js
+++ b/web-components/dist/merch-card.js
@@ -2122,6 +2122,9 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     inset-inline-end: 0;
     line-height: 16px;
   }
+  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span{
+    min-height: auto;
+  }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {
     left: 0;

--- a/web-components/dist/merch-card.js
+++ b/web-components/dist/merch-card.js
@@ -2122,7 +2122,8 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     inset-inline-end: 0;
     line-height: 16px;
   }
-  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span{
+
+  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
     min-height: auto;
   }
 

--- a/web-components/src/variants/mini-compare-chart-mweb.css.js
+++ b/web-components/src/variants/mini-compare-chart-mweb.css.js
@@ -1,4 +1,10 @@
-import { MOBILE_LANDSCAPE, TABLET_DOWN, TABLET_UP, DESKTOP_UP, LARGE_DESKTOP } from '../media.js';
+import {
+    MOBILE_LANDSCAPE,
+    TABLET_DOWN,
+    TABLET_UP,
+    DESKTOP_UP,
+    LARGE_DESKTOP,
+} from '../media.js';
 export const CSS = `
   :root {
     --list-checked-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width='20' height='20'%3E%3Cpath fill='%23222222' d='M15.656,3.8625l-.7275-.5665a.5.5,0,0,0-.7.0875L7.411,12.1415,4.0875,8.8355a.5.5,0,0,0-.707,0L2.718,9.5a.5.5,0,0,0,0,.707l4.463,4.45a.5.5,0,0,0,.75-.0465L15.7435,4.564A.5.5,0,0,0,15.656,3.8625Z'%3E%3C/path%3E%3C/svg%3E");

--- a/web-components/src/variants/mini-compare-chart-mweb.css.js
+++ b/web-components/src/variants/mini-compare-chart-mweb.css.js
@@ -1,10 +1,4 @@
-import {
-    MOBILE_LANDSCAPE,
-    TABLET_DOWN,
-    TABLET_UP,
-    DESKTOP_UP,
-    LARGE_DESKTOP,
-} from '../media.js';
+import { MOBILE_LANDSCAPE, TABLET_DOWN, TABLET_UP, DESKTOP_UP, LARGE_DESKTOP } from '../media.js';
 export const CSS = `
   :root {
     --list-checked-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width='20' height='20'%3E%3Cpath fill='%23222222' d='M15.656,3.8625l-.7275-.5665a.5.5,0,0,0-.7.0875L7.411,12.1415,4.0875,8.8355a.5.5,0,0,0-.707,0L2.718,9.5a.5.5,0,0,0,0,.707l4.463,4.45a.5.5,0,0,0,.75-.0465L15.7435,4.564A.5.5,0,0,0,15.656,3.8625Z'%3E%3C/path%3E%3C/svg%3E");
@@ -29,6 +23,10 @@ export const CSS = `
     top: 16px;
     inset-inline-end: 0;
     line-height: 16px;
+  }
+
+  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
+    min-height: auto;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-195904

## Why
Badge span elements had fixed min-height that caused misalignment of the OST savings percentage text.

## What changed
- Set badge span min-height to auto for proper text alignment in mini-compare-chart-mweb variant
- Updated generated distribution files

## Test
- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-195904--mas--adobecom.aem.live/studio.html#content-type=merch-card&fragmentId=6f0c7ac9-2998-467e-8057-f5b8e11977e5&locale=fr_FR&page=fragment-editor&path=acom