### PR TITLE
fix(mini-compare-chart-mweb): set badge span line-height to 1

### DIFF
--- a/web-components/dist/mas.js
+++ b/web-components/dist/mas.js
@@ -2632,7 +2632,7 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
   }
 
   merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    min-height: auto;
+    line-height: 1;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {

--- a/web-components/dist/mas.js
+++ b/web-components/dist/mas.js
@@ -1550,6 +1550,12 @@ merch-card[variant="catalog"] [slot="footer"] .spectrum-Link--primary {
     min-width: 1px;
   }
 
+  merch-card[variant="mini-compare-chart"] merch-badge span,
+  merch-card[variant="mini-compare-chart"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
+  }
+
   merch-card[variant="mini-compare-chart"] [slot="heading-m-price"]  {
     min-height: 30px;
     line-height: 30px;
@@ -2631,10 +2637,6 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     line-height: 16px;
   }
 
-  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    line-height: 1;
-  }
-
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {
     left: 0;
     right: initial;
@@ -2684,6 +2686,12 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     display: inline-block;
     min-height: 30px;
     min-width: 1px;
+  }
+
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge span,
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] .price-unit-type.disabled,

--- a/web-components/dist/merch-card-collection.js
+++ b/web-components/dist/merch-card-collection.js
@@ -1517,7 +1517,7 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
   }
 
   merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    min-height: auto;
+    line-height: 1;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {

--- a/web-components/dist/merch-card-collection.js
+++ b/web-components/dist/merch-card-collection.js
@@ -435,6 +435,12 @@ merch-card[variant="catalog"] [slot="footer"] .spectrum-Link--primary {
     min-width: 1px;
   }
 
+  merch-card[variant="mini-compare-chart"] merch-badge span,
+  merch-card[variant="mini-compare-chart"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
+  }
+
   merch-card[variant="mini-compare-chart"] [slot="heading-m-price"]  {
     min-height: 30px;
     line-height: 30px;
@@ -1516,10 +1522,6 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     line-height: 16px;
   }
 
-  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    line-height: 1;
-  }
-
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {
     left: 0;
     right: initial;
@@ -1569,6 +1571,12 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     display: inline-block;
     min-height: 30px;
     min-width: 1px;
+  }
+
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge span,
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] .price-unit-type.disabled,

--- a/web-components/dist/merch-card.js
+++ b/web-components/dist/merch-card.js
@@ -1042,6 +1042,12 @@ merch-card[variant="catalog"] [slot="footer"] .spectrum-Link--primary {
     min-width: 1px;
   }
 
+  merch-card[variant="mini-compare-chart"] merch-badge span,
+  merch-card[variant="mini-compare-chart"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
+  }
+
   merch-card[variant="mini-compare-chart"] [slot="heading-m-price"]  {
     min-height: 30px;
     line-height: 30px;
@@ -2123,10 +2129,6 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     line-height: 16px;
   }
 
-  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    line-height: 1;
-  }
-
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {
     left: 0;
     right: initial;
@@ -2176,6 +2178,12 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
     display: inline-block;
     min-height: 30px;
     min-width: 1px;
+  }
+
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge span,
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] .price-unit-type.disabled,

--- a/web-components/dist/merch-card.js
+++ b/web-components/dist/merch-card.js
@@ -2124,7 +2124,7 @@ merch-card[variant="mini-compare-chart"] merch-mnemonic-list:nth-child(8) {
   }
 
   merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    min-height: auto;
+    line-height: 1;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {

--- a/web-components/src/variants/mini-compare-chart-mweb.css.js
+++ b/web-components/src/variants/mini-compare-chart-mweb.css.js
@@ -31,10 +31,6 @@ export const CSS = `
     line-height: 16px;
   }
 
-  merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    line-height: 1;
-  }
-
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {
     left: 0;
     right: initial;
@@ -84,6 +80,12 @@ export const CSS = `
     display: inline-block;
     min-height: 30px;
     min-width: 1px;
+  }
+
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge span,
+  merch-card[variant="mini-compare-chart-mweb"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] .price-unit-type.disabled,

--- a/web-components/src/variants/mini-compare-chart-mweb.css.js
+++ b/web-components/src/variants/mini-compare-chart-mweb.css.js
@@ -32,7 +32,7 @@ export const CSS = `
   }
 
   merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span {
-    min-height: auto;
+    line-height: 1;
   }
 
   merch-card[variant="mini-compare-chart-mweb"] div[class$='-badge']:dir(rtl) {

--- a/web-components/src/variants/mini-compare-chart.css.js
+++ b/web-components/src/variants/mini-compare-chart.css.js
@@ -93,6 +93,12 @@ export const CSS = `
     min-width: 1px;
   }
 
+  merch-card[variant="mini-compare-chart"] merch-badge span,
+  merch-card[variant="mini-compare-chart"] merch-badge [is="inline-price"] {
+    line-height: 1;
+    min-height: auto;
+  }
+
   merch-card[variant="mini-compare-chart"] [slot="heading-m-price"]  {
     min-height: 30px;
     line-height: 30px;


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-195467
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

## Why

Badge `<span>` elements inside `mini-compare-chart-mweb` cards inherit a `line-height` that shifts the badge text vertically. Setting `line-height: 1` on the span aligns it correctly.

## What changed

- Added `merch-card[variant="mini-compare-chart-mweb"] [slot="badge"] span { line-height: 1; }` to `mini-compare-chart-mweb.css.js`
- Rebuilt dist files

Please do the steps below before submitting your PR for a code review or QA

- [ ] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [ ] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## 🧪 Nala E2E Tests

Nala tests run automatically when you **open this PR**.

### To run Nala tests again:

1. Add the `run nala` label to this PR (in the right sidebar)
2. Tests will run automatically on the current commit
3. Any future commits will also trigger tests **as long as the label remains**

### To stop automatic Nala tests:

- Remove the `run nala` label

> **Note**: Tests only run on commits if the `run nala` label is present. Add the label whenever you need tests to run on new changes.

## Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-195467--mas--adobecom.aem.live/