### PR TITLE
MWPW-195921 fix(plans): restore horizontal mnemonic layout on mobile

### DIFF
--- a/web-components/dist/mas.js
+++ b/web-components/dist/mas.js
@@ -4039,6 +4039,11 @@ merch-card-collection:has([slot="subtitle"]) merch-card {
         width: 100%;
     }
 
+    merch-whats-included merch-mnemonic-list:not(:has([slot="description"] span:not(:empty))) {
+        width: auto;
+        margin-right: unset;
+    }
+
     merch-card[variant="plans-education"] .spacer {
         height: 0px;
     }

--- a/web-components/dist/merch-card-collection.js
+++ b/web-components/dist/merch-card-collection.js
@@ -2924,6 +2924,11 @@ merch-card-collection:has([slot="subtitle"]) merch-card {
         width: 100%;
     }
 
+    merch-whats-included merch-mnemonic-list:not(:has([slot="description"] span:not(:empty))) {
+        width: auto;
+        margin-right: unset;
+    }
+
     merch-card[variant="plans-education"] .spacer {
         height: 0px;
     }

--- a/web-components/dist/merch-card.js
+++ b/web-components/dist/merch-card.js
@@ -3531,6 +3531,11 @@ merch-card-collection:has([slot="subtitle"]) merch-card {
         width: 100%;
     }
 
+    merch-whats-included merch-mnemonic-list:not(:has([slot="description"] span:not(:empty))) {
+        width: auto;
+        margin-right: unset;
+    }
+
     merch-card[variant="plans-education"] .spacer {
         height: 0px;
     }

--- a/web-components/src/variants/plans.css.js
+++ b/web-components/src/variants/plans.css.js
@@ -411,6 +411,11 @@ merch-card-collection:has([slot="subtitle"]) merch-card {
         width: 100%;
     }
 
+    merch-whats-included merch-mnemonic-list:not(:has([slot="description"] span:not(:empty))) {
+        width: auto;
+        margin-right: unset;
+    }
+
     merch-card[variant="plans-education"] .spacer {
         height: 0px;
     }


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-195921

## Why

The mobile layout for `merch-mnemonic-list` needed two distinct behaviors depending on whether the description slot has content:
- No description → horizontal layout (`width: auto`, `margin-right: unset`)
- Has description → stacked layout (`width: 100%`, margin preserved)

## What changed

- Split the mobile `merch-mnemonic-list` rule into two mutually exclusive selectors scoped by description slot content

## Test

- [ ] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR
- [ ] C6. Read your Jira one more time to validate that you've addressed all ACs and nothing is missing

## Test URLs

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-195921--mas--adobecom.aem.live/