### PR TITLE
MWPW-196146 fix(docs): use relative path for mas.js documentation link

### DIFF
--- a/web-components/docs/mas.html
+++ b/web-components/docs/mas.html
@@ -60,7 +60,7 @@
 </ul>
 </li>
 <li>
-<p><strong>mas.js</strong>: A JavaScript library to enable “4” on any page. <a href="/libs/features/mas/docs/mas.js.html" class="con-button primary-link">mas.js documentation</a></p>
+<p><strong>mas.js</strong>: A JavaScript library to enable “4” on any page. <a href="mas.js.html" class="con-button primary-link">mas.js documentation</a></p>
 </li>
 </ol>
 <h2 id="terminology" tabindex="-1">Terminology <a class="header-anchor" href="#terminology" href="#terminology" title="Permalink to this heading">#</a></h2>

--- a/web-components/docs/src/mas.md
+++ b/web-components/docs/src/mas.md
@@ -32,7 +32,7 @@ MAS includes the following key components:
     - Core commerce for basic functionality
     - UI components for user interface elements
 
-5. **mas.js**: A JavaScript library to enable "4" on any page. [mas.js documentation](/libs/features/mas/docs/mas.js.html){.con-button .primary-link}
+5. **mas.js**: A JavaScript library to enable "4" on any page. [mas.js documentation](mas.js.html){.con-button .primary-link}
 
 ## Terminology
 


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-196146
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [ ] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [x] C3. Verify all Checks are green (unit tests, nala tests)
- [x] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [x] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## 🧪 Nala E2E Tests

Nala tests run automatically when you **open this PR**.

### To run Nala tests again:

1. Add the `run nala` label to this PR (in the right sidebar)
2. Tests will run automatically on the current commit
3. Any future commits will also trigger tests **as long as the label remains**

### To stop automatic Nala tests:

- Remove the `run nala` label

> **Note**: Tests only run on commits if the `run nala` label is present. Add the label whenever you need tests to run on new changes.

## Test URLs:

- Before: https://main--mas--adobecom.aem.live/web-components/docs/mas.html (click "mas.js documentation" → 404)
- After: https://mwpw-196146--mas--adobecom.aem.live/web-components/docs/mas.html (click "mas.js documentation" → loads mas.js.html)

## Summary

The "mas.js documentation" link on `web-components/docs/mas.html` pointed to the absolute Milo path `/libs/features/mas/docs/mas.js.html`, which 404s on mas.adobe.com. The actual `mas.js.html` is colocated next to `mas.html`; switched the `href` to the relative path, consistent with all other links on the page.