### PR TITLE
MWPW-196456: Bulk-publish Product Code parity, taxonomy filters, and Status filter

### DIFF
--- a/studio/src/common/components/mas-search-and-filters.js
+++ b/studio/src/common/components/mas-search-and-filters.js
@@ -4,14 +4,30 @@ import { VARIANTS } from '../../editors/variant-picker.js';
 import { styles } from './mas-search-and-filters.css.js';
 import Store from '../../store.js';
 import { getItemsSelectionStore } from '../items-selection-store.js';
-import { FILTER_TYPE, TABLE_TYPE } from '../../constants.js';
+import { FILTER_TYPE, TABLE_TYPE, FRAGMENT_STATUS } from '../../constants.js';
 import ReactiveController from '../../reactivity/reactive-controller.js';
 import { AEM } from '../../aem/aem.js';
 import { getNamespaceCache, setNamespaceCache } from '../../aem/tag-cache.js';
 import { toAttribute } from '../../aem/tag-path-utils.js';
+import { isPznCountryTagPath } from '../utils/personalization-utils.js';
 
 const MAS_TAG_NAMESPACE = '/content/cq:tags/mas';
-const CUSTOM_TAG_ROOT = `${MAS_TAG_NAMESPACE}/custom/`;
+
+const TAXONOMY_FILTERS = [
+    { optionsProp: 'marketSegmentOptions', root: 'market_segments' },
+    { optionsProp: 'customerSegmentOptions', root: 'customer_segment' },
+    { optionsProp: 'productOptions', root: 'product_code', directChildrenOnly: true },
+    { optionsProp: 'offerTypeOptions', root: 'offer_type' },
+    { optionsProp: 'planTypeOptions', root: 'plan_type' },
+    { optionsProp: 'pznOptions', root: 'pzn', exclude: isPznCountryTagPath },
+    { optionsProp: 'tagOptions', root: 'custom' },
+];
+
+const STATUS_OPTIONS = [
+    { id: FRAGMENT_STATUS.PUBLISHED, title: 'Published' },
+    { id: FRAGMENT_STATUS.DRAFT, title: 'Draft' },
+    { id: FRAGMENT_STATUS.MODIFIED, title: 'Modified' },
+];
 
 class MasSearchAndFilters extends LitElement {
     static styles = styles;
@@ -30,6 +46,7 @@ class MasSearchAndFilters extends LitElement {
         planTypeFilter: { type: Array, state: true },
         pznFilter: { type: Array, state: true },
         tagFilter: { type: Array, state: true },
+        statusFilter: { type: Array, state: true },
         templateOptions: { type: Array },
         marketSegmentOptions: { type: Array },
         customerSegmentOptions: { type: Array },
@@ -38,6 +55,7 @@ class MasSearchAndFilters extends LitElement {
         planTypeOptions: { type: Array },
         pznOptions: { type: Array },
         tagOptions: { type: Array },
+        statusOptions: { type: Array },
         searchOnly: { type: Boolean, reflect: true },
         promotionSurfaceOptions: { type: Array },
         promotionSurface: { type: String },
@@ -54,6 +72,7 @@ class MasSearchAndFilters extends LitElement {
         this.planTypeFilter = [];
         this.pznFilter = [];
         this.tagFilter = [];
+        this.statusFilter = [];
         this.templateOptions = [];
         this.marketSegmentOptions = [];
         this.customerSegmentOptions = [];
@@ -62,6 +81,7 @@ class MasSearchAndFilters extends LitElement {
         this.planTypeOptions = [];
         this.pznOptions = [];
         this.tagOptions = [];
+        this.statusOptions = [];
         this.dataSubscription = null;
         this.promotionSurfaceOptions = [];
         this.promotionSurface = '';
@@ -81,9 +101,6 @@ class MasSearchAndFilters extends LitElement {
             ...(this.type !== TABLE_TYPE.PLACEHOLDERS ? [Store.fragments.list.firstPageLoaded] : []),
         ]);
         const dataCallback = () => {
-            if (!this.searchOnly) {
-                this.#extractFilterOptions();
-            }
             this.#applyFilters();
             this.requestUpdate();
         };
@@ -92,7 +109,12 @@ class MasSearchAndFilters extends LitElement {
             unsubscribe: () => selectionStore[`all${this.typeUppercased}`].unsubscribe(dataCallback),
         };
         if (!this.searchOnly && this.type !== TABLE_TYPE.PLACEHOLDERS) {
-            this.#loadCustomTagOptions();
+            this.templateOptions = VARIANTS.filter((variant) => variant.label.toLowerCase() !== 'all').map((variant) => ({
+                id: variant.value,
+                title: variant.label,
+            }));
+            this.statusOptions = STATUS_OPTIONS;
+            this.#loadTaxonomyFilterOptions();
         }
     }
 
@@ -137,6 +159,7 @@ class MasSearchAndFilters extends LitElement {
         const planTypeMap = new Map(this.planTypeOptions.map((opt) => [opt.id || opt.value, opt]));
         const pznMap = new Map(this.pznOptions.map((opt) => [opt.id || opt.value, opt]));
         const tagMap = new Map(this.tagOptions.map((opt) => [opt.id || opt.value, opt]));
+        const statusMap = new Map(this.statusOptions.map((opt) => [opt.id || opt.value, opt]));
 
         for (const id of this.templateFilter) {
             const option = templateMap.get(id);
@@ -170,50 +193,14 @@ class MasSearchAndFilters extends LitElement {
             const option = tagMap.get(id);
             if (option) filters.push({ type: FILTER_TYPE.TAG, id, label: option.title || option.label });
         }
+        for (const id of this.statusFilter) {
+            const option = statusMap.get(id);
+            if (option) filters.push({ type: FILTER_TYPE.STATUS, id, label: option.title || option.label });
+        }
         return filters;
     }
 
-    #extractFilterOptions() {
-        const marketSegments = new Map();
-        const customerSegments = new Map();
-        const products = new Map();
-        const offerTypes = new Map();
-        const planTypes = new Map();
-        const pzns = new Map();
-        for (const fragment of getItemsSelectionStore()[`all${this.typeUppercased}`].value) {
-            if (!fragment.tags) continue;
-
-            for (const tag of fragment.tags) {
-                const tagId = tag.id || '';
-                const tagTitle = tag.title || tagId.split('/').pop() || '';
-                if (tagId.startsWith('mas:market_segment/') || tagId.startsWith('mas:market_segments/')) {
-                    marketSegments.set(tagId, { id: tagId, title: tagTitle });
-                } else if (tagId.startsWith('mas:customer_segment/')) {
-                    customerSegments.set(tagId, { id: tagId, title: tagTitle });
-                } else if (tagId.startsWith('mas:product_code/')) {
-                    products.set(tagId, { id: tagId, title: tagTitle });
-                } else if (tagId.startsWith('mas:offer_type/')) {
-                    offerTypes.set(tagId, { id: tagId, title: tagTitle });
-                } else if (tagId.startsWith('mas:plan_type/')) {
-                    planTypes.set(tagId, { id: tagId, title: tagTitle });
-                } else if (tagId.startsWith('mas:pzn/')) {
-                    pzns.set(tagId, { id: tagId, title: tagTitle });
-                }
-            }
-        }
-        this.templateOptions = VARIANTS.filter((variant) => variant.label.toLowerCase() !== 'all').map((variant) => ({
-            id: variant.value,
-            title: variant.label,
-        }));
-        this.marketSegmentOptions = Array.from(marketSegments.values()).sort((a, b) => a.title.localeCompare(b.title));
-        this.customerSegmentOptions = Array.from(customerSegments.values()).sort((a, b) => a.title.localeCompare(b.title));
-        this.productOptions = Array.from(products.values()).sort((a, b) => a.title.localeCompare(b.title));
-        this.offerTypeOptions = Array.from(offerTypes.values()).sort((a, b) => a.title.localeCompare(b.title));
-        this.planTypeOptions = Array.from(planTypes.values()).sort((a, b) => a.title.localeCompare(b.title));
-        this.pznOptions = Array.from(pzns.values()).sort((a, b) => a.title.localeCompare(b.title));
-    }
-
-    async #loadCustomTagOptions() {
+    async #loadTaxonomyFilterOptions() {
         let data = getNamespaceCache(MAS_TAG_NAMESPACE);
         if (!data) {
             const aem = new AEM(null, document.querySelector('meta[name="aem-base-url"]')?.content);
@@ -233,10 +220,19 @@ class MasSearchAndFilters extends LitElement {
             data = getNamespaceCache(MAS_TAG_NAMESPACE);
         }
         if (!data || data instanceof Promise) return;
-        this.tagOptions = [...data.values()]
-            .filter((tag) => tag.path.startsWith(CUSTOM_TAG_ROOT) && tag.path !== CUSTOM_TAG_ROOT.slice(0, -1))
-            .map((tag) => ({ id: toAttribute([tag.path]), title: tag.title || tag.name || tag.path.split('/').pop() }))
-            .sort((a, b) => a.title.localeCompare(b.title));
+        const tags = [...data.values()];
+        for (const { optionsProp, root, exclude, directChildrenOnly } of TAXONOMY_FILTERS) {
+            const rootPath = `${MAS_TAG_NAMESPACE}/${root}/`;
+            const matching = tags.filter((tag) => {
+                if (!tag.path.startsWith(rootPath)) return false;
+                if (exclude && exclude(tag.path)) return false;
+                if (directChildrenOnly && tag.path.slice(rootPath.length).includes('/')) return false;
+                return true;
+            });
+            this[optionsProp] = matching
+                .map((tag) => ({ id: toAttribute([tag.path]), title: tag.title || tag.name || tag.path.split('/').pop() }))
+                .sort((a, b) => a.title.localeCompare(b.title));
+        }
     }
 
     willUpdate(changed) {
@@ -249,7 +245,8 @@ class MasSearchAndFilters extends LitElement {
             changed.has('offerTypeFilter') ||
             changed.has('planTypeFilter') ||
             changed.has('pznFilter') ||
-            changed.has('tagFilter')
+            changed.has('tagFilter') ||
+            changed.has('statusFilter')
         ) {
             this.#applyFilters();
         }
@@ -282,6 +279,9 @@ class MasSearchAndFilters extends LitElement {
                 break;
             case FILTER_TYPE.TAG:
                 currentValues = [...this.tagFilter];
+                break;
+            case FILTER_TYPE.STATUS:
+                currentValues = [...this.statusFilter];
                 break;
             default:
                 currentValues = [];
@@ -320,6 +320,9 @@ class MasSearchAndFilters extends LitElement {
             case FILTER_TYPE.TAG:
                 this.tagFilter = currentValues;
                 break;
+            case FILTER_TYPE.STATUS:
+                this.statusFilter = currentValues;
+                break;
         }
     }
 
@@ -353,6 +356,9 @@ class MasSearchAndFilters extends LitElement {
             case FILTER_TYPE.TAG:
                 this.tagFilter = this.tagFilter.filter((filterId) => filterId !== id);
                 break;
+            case FILTER_TYPE.STATUS:
+                this.statusFilter = this.statusFilter.filter((filterId) => filterId !== id);
+                break;
         }
     }
 
@@ -365,6 +371,7 @@ class MasSearchAndFilters extends LitElement {
         this.planTypeFilter = [];
         this.pznFilter = [];
         this.tagFilter = [];
+        this.statusFilter = [];
     }
 
     resetFilters() {
@@ -470,6 +477,10 @@ class MasSearchAndFilters extends LitElement {
         `;
     }
 
+    #fragmentMatchesAnyTag(fragment, selectedIds) {
+        return fragment.tags?.some((tag) => selectedIds.some((sel) => tag.id === sel || tag.id?.startsWith(`${sel}/`)));
+    }
+
     #applyFilters() {
         const source = getItemsSelectionStore()[`all${this.typeUppercased}`].value || [];
         const query = this.searchQuery?.toLowerCase();
@@ -481,6 +492,7 @@ class MasSearchAndFilters extends LitElement {
         const hasPlanType = this.planTypeFilter?.length > 0;
         const hasPzn = this.pznFilter?.length > 0;
         const hasTag = this.tagFilter?.length > 0;
+        const hasStatus = this.statusFilter?.length > 0;
 
         const result = source.filter((fragment) => {
             if (query) {
@@ -512,14 +524,17 @@ class MasSearchAndFilters extends LitElement {
                 if (!variantField?.values?.length) return false;
                 if (!variantField.values.some((value) => this.templateFilter.includes(value))) return false;
             }
+            if (hasStatus) {
+                if (!this.statusFilter.includes(fragment.status)) return false;
+            }
             if (hasMarket) {
-                if (!fragment.tags?.some((tag) => this.marketSegmentFilter.includes(tag.id))) return false;
+                if (!this.#fragmentMatchesAnyTag(fragment, this.marketSegmentFilter)) return false;
             }
             if (hasCustomer) {
-                if (!fragment.tags?.some((tag) => this.customerSegmentFilter.includes(tag.id))) return false;
+                if (!this.#fragmentMatchesAnyTag(fragment, this.customerSegmentFilter)) return false;
             }
             if (hasProduct) {
-                if (!fragment.tags?.some((tag) => this.productFilter.includes(tag.id))) return false;
+                if (!this.#fragmentMatchesAnyTag(fragment, this.productFilter)) return false;
             }
             if (hasOfferType) {
                 if (!fragment.tags?.some((tag) => this.offerTypeFilter.includes(tag.id))) return false;
@@ -574,8 +589,9 @@ class MasSearchAndFilters extends LitElement {
                     this.customerSegmentFilter,
                     FILTER_TYPE.CUSTOMER_SEGMENT,
                 )}
-                ${this.#renderFilterPicker('Product', this.productOptions, this.productFilter, FILTER_TYPE.PRODUCT)}
+                ${this.#renderFilterPicker('Product Code', this.productOptions, this.productFilter, FILTER_TYPE.PRODUCT)}
                 ${this.#renderFilterPicker('Tag', this.tagOptions, this.tagFilter, FILTER_TYPE.TAG)}
+                ${this.#renderFilterPicker('Status', this.statusOptions, this.statusFilter, FILTER_TYPE.STATUS)}
                 ${this.#renderFilterPicker('Personalization', this.pznOptions, this.pznFilter, FILTER_TYPE.PZN)}
                 ${surfacePicker}
             </div>

--- a/studio/src/constants.js
+++ b/studio/src/constants.js
@@ -261,6 +261,7 @@ export const FILTER_TYPE = {
     PLAN_TYPE: 'planType',
     PZN: 'pzn',
     TAG: 'tag',
+    STATUS: 'status',
 };
 
 export const FRAGMENT_STATUS = {

--- a/studio/test/translation/mas-search-and-filters.test.js
+++ b/studio/test/translation/mas-search-and-filters.test.js
@@ -10,14 +10,29 @@ import '../../src/swc.js';
 import '../../src/common/components/mas-search-and-filters.js';
 
 const MAS_TAG_NAMESPACE = '/content/cq:tags/mas';
-const seedCustomTagTaxonomy = (titles = ['Accordion', 'Marquee', 'Test']) => {
-    const entries = titles.map((title) => {
-        const slug = title.toLowerCase().replace(/\s+/g, '-');
-        const path = `/content/cq:tags/mas/custom/${slug}`;
-        return [path, { path, title, name: slug }];
-    });
+
+// Seed the shared taxonomy cache with tags under one or more roots.
+// seedTaxonomy({ custom: ['Accordion'], pzn: [['edu', 'EDU']] }) — value is a title (slug derived)
+// or a [slug, title] pair, or a full cq path string.
+const seedTaxonomy = (byRoot) => {
+    const entries = [];
+    for (const [root, values] of Object.entries(byRoot)) {
+        for (const value of values) {
+            let path, title, slug;
+            if (typeof value === 'string' && value.startsWith('/content/cq:tags/')) {
+                path = value;
+                slug = path.split('/').pop();
+                title = slug;
+            } else {
+                [slug, title] = Array.isArray(value) ? value : [value.toLowerCase().replace(/\s+/g, '-'), value];
+                path = `/content/cq:tags/mas/${root}/${slug}`;
+            }
+            entries.push([path, { path, title, name: slug }]);
+        }
+    }
     setNamespaceCache(MAS_TAG_NAMESPACE, new Map(entries));
 };
+const seedCustomTagTaxonomy = (titles = ['Accordion', 'Marquee', 'Test']) => seedTaxonomy({ custom: titles });
 
 describe('MasSearchAndFilters', () => {
     let sandbox;
@@ -103,6 +118,11 @@ describe('MasSearchAndFilters', () => {
         it('should have templateOptions populated from VARIANTS when not searchOnly', async () => {
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             expect(el.templateOptions.length).to.be.greaterThan(0);
+        });
+
+        it('should initialize statusFilter as empty', async () => {
+            const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+            expect(el.statusFilter).to.deep.equal([]);
         });
     });
 
@@ -248,26 +268,23 @@ describe('MasSearchAndFilters', () => {
             expect(filters).to.be.null;
         });
 
-        const fragmentWithEveryFilterTag = () =>
-            createMockFragment({
-                tags: [
-                    { id: 'mas:market_segment/com', title: 'Commercial' },
-                    { id: 'mas:customer_segment/individual', title: 'Individual' },
-                    { id: 'mas:product_code/photoshop', title: 'Photoshop' },
-                    { id: 'mas:offer_type/base', title: 'Base' },
-                    { id: 'mas:plan_type/abm', title: 'ABM' },
-                    { id: 'mas:custom/featured', title: 'Featured' },
-                    { id: 'mas:pzn/country/us', title: 'US' },
-                ],
+        const seedEveryFilterTaxonomy = () =>
+            seedTaxonomy({
+                market_segments: [['com', 'Commercial']],
+                customer_segment: [['individual', 'Individual']],
+                product_code: [['photoshop', 'Photoshop']],
+                offer_type: [['base', 'Base']],
+                plan_type: [['abm', 'ABM']],
+                custom: ['Featured'],
+                pzn: [['edu', 'EDU']],
             });
 
-        it('should render all eight filter triggers when every bucket has options', async () => {
-            seedCustomTagTaxonomy(['Featured']);
-            Store.translationProjects.allCards.set([fragmentWithEveryFilterTag()]);
+        it('should render all nine filter triggers when every bucket has options', async () => {
+            seedEveryFilterTaxonomy();
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
             const filterTriggers = el.shadowRoot.querySelectorAll('.filter-trigger');
-            expect(filterTriggers.length).to.equal(8);
+            expect(filterTriggers.length).to.equal(9);
         });
 
         it('should not render a filter trigger when its bucket has no options', async () => {
@@ -283,7 +300,7 @@ describe('MasSearchAndFilters', () => {
         });
 
         it('should render Market Segment filter', async () => {
-            Store.translationProjects.allCards.set([fragmentWithEveryFilterTag()]);
+            seedEveryFilterTaxonomy();
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
             const filters = el.shadowRoot.querySelector('.filters');
@@ -291,7 +308,7 @@ describe('MasSearchAndFilters', () => {
         });
 
         it('should render Customer Segment filter', async () => {
-            Store.translationProjects.allCards.set([fragmentWithEveryFilterTag()]);
+            seedEveryFilterTaxonomy();
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
             const filters = el.shadowRoot.querySelector('.filters');
@@ -299,16 +316,23 @@ describe('MasSearchAndFilters', () => {
         });
 
         it('should render Product filter', async () => {
-            Store.translationProjects.allCards.set([fragmentWithEveryFilterTag()]);
+            seedEveryFilterTaxonomy();
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
             const filters = el.shadowRoot.querySelector('.filters');
             expect(filters.textContent).to.include('Product');
         });
 
+        it('labels the product filter "Product Code"', async () => {
+            seedTaxonomy({ product_code: [['ccsn', 'Creative Cloud']] });
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            await el.updateComplete;
+            const filters = el.shadowRoot.querySelector('.filters');
+            expect(filters.textContent).to.include('Product Code');
+        });
+
         it('should render Tag filter', async () => {
-            seedCustomTagTaxonomy(['Featured']);
-            Store.translationProjects.allCards.set([fragmentWithEveryFilterTag()]);
+            seedEveryFilterTaxonomy();
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
             const filters = el.shadowRoot.querySelector('.filters');
@@ -496,116 +520,99 @@ describe('MasSearchAndFilters', () => {
         });
     });
 
-    describe('filter extraction', () => {
-        it('should extract market segment options from fragments', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/com', title: 'Commercial' }],
-                }),
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/edu', title: 'Education' }],
-                }),
-            ]);
+    describe('filter options from taxonomy', () => {
+        it('populates every tag-based filter from the AEM taxonomy, not loaded fragments', async () => {
+            seedTaxonomy({
+                market_segments: [
+                    ['com', 'Commercial'],
+                    ['edu', 'Education'],
+                ],
+                customer_segment: [['individual', 'Individual']],
+                product_code: [['photoshop', 'Photoshop']],
+                offer_type: [['base', 'Base']],
+                plan_type: [['abm', 'ABM']],
+                custom: ['Featured'],
+            });
+            Store.translationProjects.allCards.set([createMockFragment({ tags: [] })]);
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
-            expect(el.marketSegmentOptions.length).to.equal(2);
+            expect(el.marketSegmentOptions.map((o) => o.id)).to.have.members([
+                'mas:market_segments/com',
+                'mas:market_segments/edu',
+            ]);
+            expect(el.customerSegmentOptions.map((o) => o.id)).to.deep.equal(['mas:customer_segment/individual']);
+            expect(el.productOptions.map((o) => o.id)).to.deep.equal(['mas:product_code/photoshop']);
+            expect(el.offerTypeOptions.map((o) => o.id)).to.deep.equal(['mas:offer_type/base']);
+            expect(el.planTypeOptions.map((o) => o.id)).to.deep.equal(['mas:plan_type/abm']);
+            expect(el.tagOptions.map((o) => o.id)).to.deep.equal(['mas:custom/featured']);
         });
 
-        it('should extract market segment options with alternate prefix', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segments/com', title: 'Commercial' }],
-                }),
-            ]);
+        it('renders tag-based filters even when no loaded fragment carries those tags', async () => {
+            seedTaxonomy({ market_segments: [['com', 'Commercial']], offer_type: [['base', 'Base']] });
+            Store.translationProjects.allCards.set([createMockFragment({ tags: [{ id: 'mas:plan_type/abm' }] })]);
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
-            expect(el.marketSegmentOptions.length).to.equal(1);
+            const filters = el.shadowRoot.querySelector('.filters');
+            expect(filters.textContent).to.include('Market Segment');
+            expect(filters.textContent).to.include('Offer Type');
         });
 
-        it('should extract customer segment options from fragments', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:customer_segment/individual', title: 'Individual' }],
-                }),
-            ]);
+        it('sorts options alphabetically by title', async () => {
+            seedTaxonomy({
+                market_segments: [
+                    ['zebra', 'Zebra'],
+                    ['alpha', 'Alpha'],
+                ],
+            });
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
-            expect(el.customerSegmentOptions.length).to.equal(1);
+            expect(el.marketSegmentOptions.map((o) => o.title)).to.deep.equal(['Alpha', 'Zebra']);
         });
 
-        it('should extract product options from fragments', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:product_code/photoshop', title: 'Photoshop' }],
-                }),
-            ]);
+        it('excludes pzn country tags from the Personalization options', async () => {
+            seedTaxonomy({
+                pzn: [
+                    ['edu', 'EDU'],
+                    ['general', 'General'],
+                    '/content/cq:tags/mas/pzn/country/fr_FR',
+                    '/content/cq:tags/mas/pzn/country',
+                ],
+            });
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
-            expect(el.productOptions.length).to.equal(1);
+            const ids = el.pznOptions.map((o) => o.id);
+            expect(ids).to.have.members(['mas:pzn/edu', 'mas:pzn/general']);
+            expect(ids.some((id) => id.startsWith('mas:pzn/country'))).to.be.false;
         });
 
-        it('should deduplicate options', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/com', title: 'Commercial' }],
-                }),
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/com', title: 'Commercial' }],
-                }),
-            ]);
+        it('collapses product_code options to parent-level products', async () => {
+            seedTaxonomy({
+                product_code: [
+                    ['ccsn', 'Creative Cloud'],
+                    '/content/cq:tags/mas/product_code/ccsn/photoshop',
+                    '/content/cq:tags/mas/product_code/ccsn/illustrator',
+                    ['phsp', 'Photoshop Single App'],
+                ],
+            });
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             await el.updateComplete;
-            expect(el.marketSegmentOptions.length).to.equal(1);
+            const ids = el.productOptions.map((o) => o.id);
+            expect(ids).to.have.members(['mas:product_code/ccsn', 'mas:product_code/phsp']);
+            expect(ids.some((id) => id.includes('/photoshop') || id.includes('/illustrator'))).to.be.false;
         });
 
-        it('should sort options alphabetically', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/zebra', title: 'Zebra' }],
-                }),
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/alpha', title: 'Alpha' }],
-                }),
-            ]);
-            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
-            await el.updateComplete;
-            expect(el.marketSegmentOptions[0].title).to.equal('Alpha');
-            expect(el.marketSegmentOptions[1].title).to.equal('Zebra');
-        });
-
-        it('should skip fragments without tags', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({ tags: null }),
-                createMockFragment({ tags: undefined }),
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/com', title: 'Commercial' }],
-                }),
-            ]);
-            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
-            await el.updateComplete;
-            expect(el.marketSegmentOptions.length).to.equal(1);
-        });
-
-        it('should extract title from tag id when title is missing', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/commercial' }],
-                }),
-            ]);
-            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
-            await el.updateComplete;
-            expect(el.marketSegmentOptions[0].title).to.equal('commercial');
-        });
-
-        it('should not extract filter options when searchOnly is true', async () => {
-            Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/com', title: 'Commercial' }],
-                }),
-            ]);
+        it('does not load taxonomy filter options when searchOnly is true', async () => {
+            seedTaxonomy({ market_segments: [['com', 'Commercial']] });
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${true}></mas-search-and-filters>`);
             await el.updateComplete;
             expect(el.marketSegmentOptions.length).to.equal(0);
+        });
+
+        it('renders a Status filter with Published/Draft/Modified options', async () => {
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            await el.updateComplete;
+            expect(el.statusOptions.map((o) => o.id)).to.have.members(['PUBLISHED', 'DRAFT', 'MODIFIED']);
+            expect(el.statusOptions.map((o) => o.title)).to.have.members(['Published', 'Draft', 'Modified']);
         });
     });
 
@@ -619,6 +626,30 @@ describe('MasSearchAndFilters', () => {
             el.templateFilter = ['plans'];
             await el.updateComplete;
             expect(Store.translationProjects.displayCards.get().length).to.equal(1);
+        });
+
+        it('should filter by status', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ status: 'PUBLISHED' }),
+                createMockFragment({ status: 'DRAFT' }),
+                createMockFragment({ status: 'MODIFIED' }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.statusFilter = ['PUBLISHED'];
+            await el.updateComplete;
+            expect(Store.translationProjects.displayCards.get().length).to.equal(1);
+        });
+
+        it('should filter by multiple statuses (OR within the filter)', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ status: 'PUBLISHED' }),
+                createMockFragment({ status: 'DRAFT' }),
+                createMockFragment({ status: 'MODIFIED' }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.statusFilter = ['PUBLISHED', 'MODIFIED'];
+            await el.updateComplete;
+            expect(Store.translationProjects.displayCards.get().length).to.equal(2);
         });
 
         it('should filter by market segment tag', async () => {
@@ -697,6 +728,61 @@ describe('MasSearchAndFilters', () => {
             el.templateFilter = ['plans'];
             await el.updateComplete;
             expect(Store.translationProjects.displayCards.get().length).to.equal(0);
+        });
+
+        it('should filter by offer type tag', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ tags: [{ id: 'mas:offer_type/base', title: 'Base' }] }),
+                createMockFragment({ tags: [{ id: 'mas:offer_type/trial', title: 'Trial' }] }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.offerTypeFilter = ['mas:offer_type/base'];
+            await el.updateComplete;
+            expect(Store.translationProjects.displayCards.get().length).to.equal(1);
+        });
+
+        it('should filter by plan type tag', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ tags: [{ id: 'mas:plan_type/abm', title: 'ABM' }] }),
+                createMockFragment({ tags: [{ id: 'mas:plan_type/puf', title: 'PUF' }] }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.planTypeFilter = ['mas:plan_type/abm'];
+            await el.updateComplete;
+            expect(Store.translationProjects.displayCards.get().length).to.equal(1);
+        });
+
+        it('should filter by tag (custom)', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ tags: [{ id: 'mas:custom/featured', title: 'Featured' }] }),
+                createMockFragment({ tags: [{ id: 'mas:custom/legacy', title: 'Legacy' }] }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.tagFilter = ['mas:custom/featured'];
+            await el.updateComplete;
+            expect(Store.translationProjects.displayCards.get().length).to.equal(1);
+        });
+
+        it('should filter by personalization tag', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ tags: [{ id: 'mas:pzn/edu', title: 'EDU' }] }),
+                createMockFragment({ tags: [{ id: 'mas:pzn/general', title: 'General' }] }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.pznFilter = ['mas:pzn/edu'];
+            await el.updateComplete;
+            expect(Store.translationProjects.displayCards.get().length).to.equal(1);
+        });
+
+        it('matches a descendant product when its parent product code is selected (end-to-end)', async () => {
+            Store.translationProjects.allCards.set([
+                createMockFragment({ tags: [{ id: 'mas:product_code/ccsn/photoshop', title: 'Photoshop' }] }),
+                createMockFragment({ tags: [{ id: 'mas:product_code/other', title: 'Other' }] }),
+            ]);
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.productFilter = ['mas:product_code/ccsn'];
+            await el.updateComplete;
+            expect(Store.translationProjects.displayCards.get().length).to.equal(1);
         });
     });
 
@@ -849,28 +935,24 @@ describe('MasSearchAndFilters', () => {
     });
 
     describe('reactivity', () => {
-        it('should update when allCards store changes', async () => {
+        it('should update displayed cards when allCards store changes', async () => {
             const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
             Store.translationProjects.allCards.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/com', title: 'Commercial' }],
-                }),
+                createMockFragment({ tags: [{ id: 'mas:market_segments/com', title: 'Commercial' }] }),
             ]);
             await el.updateComplete;
-            expect(el.marketSegmentOptions.length).to.equal(1);
+            expect(Store.translationProjects.displayCards.get().length).to.equal(1);
         });
 
-        it('should update when allCollections store changes', async () => {
+        it('should update displayed collections when allCollections store changes', async () => {
             const el = await fixture(
                 html`<mas-search-and-filters type="collections" .searchOnly=${false}></mas-search-and-filters>`,
             );
             Store.translationProjects.allCollections.set([
-                createMockFragment({
-                    tags: [{ id: 'mas:market_segment/com', title: 'Commercial' }],
-                }),
+                createMockFragment({ tags: [{ id: 'mas:market_segments/com', title: 'Commercial' }] }),
             ]);
             await el.updateComplete;
-            expect(el.marketSegmentOptions.length).to.equal(1);
+            expect(Store.translationProjects.displayCollections.get().length).to.equal(1);
         });
 
         it('should update when placeholders list data changes', async () => {
@@ -1069,16 +1151,23 @@ describe('MasSearchAndFilters', () => {
             expect(el.pznFilter).to.deep.equal([]);
         });
 
-        it('extracts offer_type / plan_type / pzn options from fragment tags', async () => {
-            Store.translationProjects.allCards.set([
-                fragmentWithTags(['mas:offer_type/base', 'mas:plan_type/abm', 'mas:pzn/country/us']),
-                fragmentWithTags(['mas:offer_type/trial', 'mas:plan_type/puf']),
-            ]);
+        it('populates offer_type / plan_type / pzn options from the taxonomy', async () => {
+            seedTaxonomy({
+                offer_type: [
+                    ['base', 'Base'],
+                    ['trial', 'Trial'],
+                ],
+                plan_type: [
+                    ['abm', 'ABM'],
+                    ['puf', 'PUF'],
+                ],
+                pzn: [['general', 'General']],
+            });
             const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
             await el.updateComplete;
             expect(el.offerTypeOptions.map((o) => o.id).sort()).to.deep.equal(['mas:offer_type/base', 'mas:offer_type/trial']);
             expect(el.planTypeOptions.map((o) => o.id).sort()).to.deep.equal(['mas:plan_type/abm', 'mas:plan_type/puf']);
-            expect(el.pznOptions.map((o) => o.id)).to.deep.equal(['mas:pzn/country/us']);
+            expect(el.pznOptions.map((o) => o.id)).to.deep.equal(['mas:pzn/general']);
         });
 
         it('filters cards by offer_type', async () => {
@@ -1132,14 +1221,16 @@ describe('MasSearchAndFilters', () => {
         });
 
         it('renders applied-filters chips for new filter types', async () => {
-            Store.translationProjects.allCards.set([
-                fragmentWithTags(['mas:offer_type/base', 'mas:plan_type/abm', 'mas:pzn/country/us']),
-            ]);
+            seedTaxonomy({
+                offer_type: [['base', 'Base']],
+                plan_type: [['abm', 'ABM']],
+                pzn: [['general', 'General']],
+            });
             const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
             await el.updateComplete;
             el.offerTypeFilter = ['mas:offer_type/base'];
             el.planTypeFilter = ['mas:plan_type/abm'];
-            el.pznFilter = ['mas:pzn/country/us'];
+            el.pznFilter = ['mas:pzn/general'];
             await el.updateComplete;
             const types = el.appliedFilters.map((f) => f.type).sort();
             expect(types).to.deep.equal([FILTER_TYPE.OFFER_TYPE, FILTER_TYPE.PLAN_TYPE, FILTER_TYPE.PZN].sort());
@@ -1293,5 +1384,75 @@ describe('MasSearchAndFilters', () => {
             await el.updateComplete;
             expect(el.tagFilter).to.not.include('mas:custom/featured');
         });
+    });
+});
+
+describe('prefix-match filtering', () => {
+    let sandbox;
+    const fragmentWith = (tagIds) => ({
+        title: 'F',
+        path: '/content/dam/mas/acom/en_US/f',
+        tags: tagIds.map((id) => ({ id, title: id.split('/').pop() })),
+        fields: [],
+    });
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        setItemsSelectionStore(Store.translationProjects);
+        Store.translationProjects.allCards.set([]);
+        Store.translationProjects.displayCards.set([]);
+        Store.fragments.list.loading.set(false);
+        Store.fragments.list.firstPageLoaded.set(true);
+    });
+
+    afterEach(() => {
+        fixtureCleanup();
+        sandbox.restore();
+        Store.translationProjects.allCards.set([]);
+        Store.translationProjects.displayCards.set([]);
+        setItemsSelectionStore(null);
+    });
+
+    it('matches a fragment carrying the exact selected product code', async () => {
+        const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+        Store.translationProjects.allCards.set([fragmentWith(['mas:product_code/ccsn'])]);
+        el.productFilter = ['mas:product_code/ccsn'];
+        await el.updateComplete;
+        expect(Store.translationProjects.displayCards.value.length).to.equal(1);
+    });
+
+    it('matches a descendant when a parent product code is selected', async () => {
+        const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+        Store.translationProjects.allCards.set([fragmentWith(['mas:product_code/ccsn/photoshop'])]);
+        el.productFilter = ['mas:product_code/ccsn'];
+        await el.updateComplete;
+        expect(Store.translationProjects.displayCards.value.length).to.equal(1);
+    });
+
+    it('does NOT match a sibling whose id shares a prefix without a slash boundary', async () => {
+        const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+        Store.translationProjects.allCards.set([fragmentWith(['mas:product_code/ccx'])]);
+        el.productFilter = ['mas:product_code/cc'];
+        await el.updateComplete;
+        expect(Store.translationProjects.displayCards.value.length).to.equal(0);
+    });
+
+    it('returns zero results when no loaded fragment carries the selected tag', async () => {
+        const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+        Store.translationProjects.allCards.set([fragmentWith(['mas:product_code/other'])]);
+        el.productFilter = ['mas:product_code/ccsn'];
+        await el.updateComplete;
+        expect(Store.translationProjects.displayCards.value.length).to.equal(0);
+    });
+
+    it('applies the same prefix rule to market and customer segment', async () => {
+        const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+        Store.translationProjects.allCards.set([
+            fragmentWith(['mas:market_segments/com/edu']),
+            fragmentWith(['mas:customer_segment/individual']),
+        ]);
+        el.marketSegmentFilter = ['mas:market_segments/com'];
+        await el.updateComplete;
+        expect(Store.translationProjects.displayCards.value.length).to.equal(1);
     });
 });

--- a/studio/test/translation/mas-search-and-filters.test.js
+++ b/studio/test/translation/mas-search-and-filters.test.js
@@ -213,6 +213,14 @@ describe('MasSearchAndFilters', () => {
             ]);
         });
 
+        it('should return status filters with correct format', async () => {
+            const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
+            el.statusOptions = [{ id: 'PUBLISHED', title: 'Published' }];
+            el.statusFilter = ['PUBLISHED'];
+            await el.updateComplete;
+            expect(el.appliedFilters).to.deep.equal([{ type: FILTER_TYPE.STATUS, id: 'PUBLISHED', label: 'Published' }]);
+        });
+
         it('should return combined filters from all types', async () => {
             const el = await fixture(html`<mas-search-and-filters type="cards"></mas-search-and-filters>`);
             el.templateOptions = [{ id: 'plans', title: 'Plans' }];
@@ -613,6 +621,12 @@ describe('MasSearchAndFilters', () => {
             await el.updateComplete;
             expect(el.statusOptions.map((o) => o.id)).to.have.members(['PUBLISHED', 'DRAFT', 'MODIFIED']);
             expect(el.statusOptions.map((o) => o.title)).to.have.members(['Published', 'Draft', 'Modified']);
+        });
+
+        it('does not populate Status options when searchOnly is true', async () => {
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${true}></mas-search-and-filters>`);
+            await el.updateComplete;
+            expect(el.statusOptions.length).to.equal(0);
         });
     });
 
@@ -1287,6 +1301,18 @@ describe('MasSearchAndFilters', () => {
             tag.dispatchEvent(new CustomEvent('delete', { bubbles: true }));
             await el.updateComplete;
             expect(el.pznFilter).to.not.include('mas:pzn/country/us');
+        });
+
+        it('removes status chip on sp-tag delete', async () => {
+            const el = await fixture(html`<mas-search-and-filters type="cards" .searchOnly=${false}></mas-search-and-filters>`);
+            el.statusOptions = [{ id: 'PUBLISHED', title: 'Published' }];
+            el.statusFilter = ['PUBLISHED'];
+            await el.updateComplete;
+            const tag = el.shadowRoot.querySelector('sp-tag');
+            tag.value = { type: FILTER_TYPE.STATUS, id: 'PUBLISHED' };
+            tag.dispatchEvent(new CustomEvent('delete', { bubbles: true }));
+            await el.updateComplete;
+            expect(el.statusFilter).to.not.include('PUBLISHED');
         });
     });
 


### PR DESCRIPTION
Brings the bulk-publish "Add items" popup filters to parity with the content page, addressing the Jira follow-up (Product/Product Code mismatch, taxonomy-driven tag filters, Status filter).

Resolves https://jira.corp.adobe.com/browse/MWPW-196456

## What changed

- Source all tag filters (Market Segment, Customer Segment, Product Code, Offer Type, Plan Type, Personalization, Tag) from the AEM taxonomy via a declarative `TAXONOMY_FILTERS` table — not from loaded items — so menus match the content page.
- **Product Code**: relabeled from "Product"; options now collapse to parent-level products (mirrors the content page's `#filterToParentProductCodeTags`). Selecting a parent matches descendant-tagged fragments (parent-prefix match, `/`-boundary guarded so `cc` ≠ `ccx`).
- **Status filter** added (Published / Draft / Modified) — client-side over `fragment.status`, like the Template filter. Hidden in search-only mode.
- Content Type intentionally excluded (cards/collections already split into tabs, per Lucy).
- Unit tests cover every filter, parent-prefix matching, parent-collapse, and Status. Full studio suite green (2286 passed).

## Test URLs

- Before: https://main--mas--adobecom.aem.live/studio.html#content
- After: https://mwpw-196456-product-code-status-filters--mas--adobecom.aem.live/studio.html#content

## Screenshots

Bulk-publish Product Code filter now shows parent-level products identical to the content page; selecting "Acrobat" returns Acrobat-tagged cards.

## Checklist

- [x] Code follows project conventions
- [x] Unit tests pass locally (2286 passed, 0 failed)
- [x] Linter runs without errors
- [ ] Tested on Before/After URLs
