### PR TITLE
MWPW-197548: top nav + collapsible side nav redesign

### DIFF
--- a/studio/src/mas-locale-picker.js
+++ b/studio/src/mas-locale-picker.js
@@ -49,8 +49,11 @@ export class MasLocalePicker extends LitElement {
 
         .chevron {
             vertical-align: middle;
-            margin-left: 6px;
             margin-top: -3px;
+            /* No margin-left — Spectrum's text-to-visual gap (6px, set on
+               :host) already provides the spacing to the label, and adding a
+               second 6px makes the right side look 12px while the left
+               (icon→text) is only 6px. */
         }
 
         :host(.strong) {
@@ -70,22 +73,55 @@ export class MasLocalePicker extends LitElement {
             --mod-actionbutton-border-radius: 16px;
             --spectrum-actionbutton-height: 32px;
             --spectrum-actionbutton-min-width: auto;
+            /* Figma 15382:308970 — 12px outer padding + 6px icon-to-label gap.
+               Spectrum computes its internal gap as
+               text-to-visual + edge-to-text − edge-to-visual-only,
+               so edge-to-text and edge-to-visual-only must be equal for the
+               gap to reduce to exactly text-to-visual (6px). */
+            /* Padding/gap tokens applied via JS on the inner sp-action-button
+               (see firstUpdated) — CSS inheritance can't override sp-action-button's
+               own :host([size=m]) declarations for these tokens. */
         }
 
+        /* Component/M/Bold per Figma — Spectrum tokens for size 100. */
         .strong [slot='label'].locale-label {
             display: flex;
             align-items: center;
             gap: 6px;
             color: var(--spectrum-gray-50, #ffffff);
-            font-weight: 700;
-            font-size: 14px;
-            font-family: 'Adobe Clean', sans-serif;
+            font-family: var(--spectrum-sans-font-family-stack, 'Adobe Clean', sans-serif);
+            font-size: var(--spectrum-font-size-100, 14px);
+            line-height: var(--spectrum-line-height-100, 18px);
+            font-weight: var(--spectrum-bold-font-weight, 700);
+            letter-spacing: var(--spectrum-letter-spacing, 0);
         }
 
         .strong sp-menu-item .locale-label {
             display: flex;
             align-items: center;
             gap: 6px;
+        }
+
+        /* Same menu-item style as the folder picker (Figma 22245:321219).
+           Only active in .strong (top-nav) mode. */
+        :host(.strong) sp-menu-item {
+            --mod-menu-item-label-inline-edge-to-content: 12px;
+            --mod-menu-item-min-height: 32px;
+            --mod-menu-item-top-edge-to-text: 7px;
+            --mod-menu-item-bottom-edge-to-text: 7px;
+            --mod-menu-item-label-font-size: 14px;
+            --mod-menu-item-label-line-height: 18px;
+            --mod-menu-item-label-content-color-default: var(--alias-content-neutral-default, #292929);
+            padding-inline-start: 12px !important;
+            padding-inline-end: 12px !important;
+            padding-block-start: 7px !important;
+            padding-block-end: 7px !important;
+            border-radius: 8px;
+            font-weight: 500;
+            margin: 0 !important;
+        }
+        :host(.strong) sp-menu-item + sp-menu-item {
+            margin-top: 4px !important;
         }
 
         sp-menu-item .locale-label {
@@ -111,26 +147,53 @@ export class MasLocalePicker extends LitElement {
             line-height: 1;
         }
 
-        sp-menu {
-            padding-top: 20px;
+        /* Top-nav popover layout per Figma 11769:183597. sp-popover provides
+           8px padding inset; sp-menu lays out search + scrollable items list
+           with a 4px gap. The extra space between search and the items list
+           (12px total per Figma) comes from a margin-bottom on sp-search
+           below (12 − 4 = 8px). */
+        :host(.strong) sp-menu {
+            padding: 0 !important;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            min-width: 233px;
         }
 
-        sp-search {
+        /* Scroll is scoped to the items wrapper, NOT sp-menu — that way the
+           scrollbar track sits only beside the items list and never beneath
+           the search field above it.
+           max-height = 9 items × 32 + 8 inter-item gaps × 4 = 320px. */
+        :host(.strong) .locale-items-scroll {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            max-height: 320px;
+            overflow-y: auto;
+        }
+
+        /* Search field per Figma — 32px h, 16px radius, 2px gray-300 border.
+           8px margin-bottom + the 4px sp-menu flex gap = 12px gap to the
+           first menu item, matching Figma. */
+        :host(.strong) sp-search {
             display: block;
-            margin-left: auto;
-            margin-right: auto;
-            padding-bottom: 12px;
-            width: 80%;
-        }
-
-        sp-search {
-            --mod-search-border-color-default: var(--spectrum-gray-400, #a9a9a9ff);
+            width: 100%;
+            margin-bottom: 8px;
+            --mod-search-border-color-default: var(--spectrum-gray-300, #dadada);
             --mod-search-border-radius: 16px;
             --mod-search-border-width: 2px;
+            --mod-search-height: 32px;
         }
 
-        sp-search:focus {
+        :host(.strong) sp-search:focus {
             --spectrum-focus-indicator-color: transparent;
+        }
+
+        /* Items list — no flex gap from sp-menu (which is set to 12px between
+           search and items list); use sibling margin between items for the
+           4px row gap. */
+        :host(.strong) sp-search + sp-menu-item {
+            margin-top: 0 !important;
         }
 
         .selection-trigger {
@@ -371,9 +434,9 @@ export class MasLocalePicker extends LitElement {
     get searchField() {
         return !this.searchDisabled
             ? html` <sp-search
-                  name="locale-search"
                   size="m"
                   placeholder="${this.searchPlaceholder}"
+                  autocomplete="off"
                   @input=${this.handleSearchInput}
                   @click=${this.handleSearchFieldClick}
                   .value=${this.searchQuery}
@@ -595,6 +658,52 @@ export class MasLocalePicker extends LitElement {
         }
     }
 
+    // Override Spectrum's action-button size-m padding tokens directly on the
+    // inner sp-action-button, since :host([size=m]) declarations inside the
+    // action-button shadow always beat inherited custom-property values from
+    // outside (cascade beats inheritance regardless of !important). Inline
+    // style on the element wins via specificity (1,0,0,0). Only runs in the
+    // "strong" display mode (the pill variant shown in the top nav).
+    // Adopt a stylesheet into sp-action-menu's shadow root so both the
+    // inner sp-action-button (the EN(US) pill) and the sp-popover (its
+    // dropdown) are styled BEFORE either first paints. Only applies in
+    // .strong display mode (the top-nav variant).
+    async firstUpdated() {
+        await this.updateComplete;
+        if (this.displayMode !== 'strong') return;
+        const actionMenu = this.shadowRoot?.querySelector('sp-action-menu');
+        if (!actionMenu) return;
+        await actionMenu.updateComplete;
+        this.#adoptShadowStyles(actionMenu);
+    }
+
+    #adoptShadowStyles(actionMenu) {
+        if (!actionMenu.shadowRoot || actionMenu.dataset.shadowPatched) return;
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(`
+            sp-action-button {
+                --spectrum-actionbutton-edge-to-text: 12px;
+                --spectrum-actionbutton-edge-to-visual: 12px;
+                --spectrum-actionbutton-edge-to-visual-only: 12px;
+                --spectrum-actionbutton-text-to-visual: 6px;
+            }
+            sp-popover {
+                padding: 8px !important;
+                border-radius: 10px !important;
+                border: 1px solid transparent !important;
+                background-color: #ffffff !important;
+                box-shadow:
+                    0 0 2px rgba(0, 0, 0, 0.12),
+                    0 2px 6px rgba(0, 0, 0, 0.04),
+                    0 4px 12px rgba(0, 0, 0, 0.08) !important;
+                min-width: auto !important;
+                width: fit-content !important;
+            }
+        `);
+        actionMenu.shadowRoot.adoptedStyleSheets = [...actionMenu.shadowRoot.adoptedStyleSheets, sheet];
+        actionMenu.dataset.shadowPatched = 'true';
+    }
+
     render() {
         if (this.isCheckboxSelection) {
             return html`
@@ -627,7 +736,10 @@ export class MasLocalePicker extends LitElement {
                 </span>
                 <sp-icon-chevron-down class="chevron" slot="label"></sp-icon-chevron-down>
                 <sp-menu size="m">
-                    ${this.searchField} ${this.getFilteredLocales().map((locale) => this.renderMenuItem(locale))}
+                    ${this.searchField}
+                    <div class="locale-items-scroll">
+                        ${this.getFilteredLocales().map((locale) => this.renderMenuItem(locale))}
+                    </div>
                 </sp-menu>
             </sp-action-menu>
         `;

--- a/studio/src/mas-locale-picker.js
+++ b/studio/src/mas-locale-picker.js
@@ -37,6 +37,14 @@ export class MasLocalePicker extends LitElement {
     reactiveController = new ReactiveController(this, [Store.fragmentEditor.translatedLocales]);
 
     static styles = css`
+        /* Hide the strong-mode pill until the Spectrum shadow stylesheet
+           has been adopted (see firstUpdated) — otherwise it paints with
+           default Spectrum padding/sizes briefly before flipping to our
+           Figma values. */
+        :host(.strong:not([data-shadow-ready])) sp-action-menu {
+            visibility: hidden;
+        }
+
         sp-label {
             font-weight: 600;
             padding-right: 8px;
@@ -157,7 +165,11 @@ export class MasLocalePicker extends LitElement {
             display: flex;
             flex-direction: column;
             gap: 4px;
-            min-width: 233px;
+            /* No min-width — let the popover hug its longest menu item.
+               The Figma's 233px was the design's nominal width, but the
+               real content (English (GB), Bulgarian (BG), etc.) is much
+               narrower; forcing 233px left a lot of empty space on the
+               right side of every row. */
         }
 
         /* Scroll is scoped to the items wrapper, NOT sp-menu — that way the
@@ -668,17 +680,33 @@ export class MasLocalePicker extends LitElement {
     // inner sp-action-button (the EN(US) pill) and the sp-popover (its
     // dropdown) are styled BEFORE either first paints. Only applies in
     // .strong display mode (the top-nav variant).
-    async firstUpdated() {
-        await this.updateComplete;
+    //
+    // Important: do NOT `await actionMenu.updateComplete` first — by then
+    // the action-button is in the DOM and the browser has typically already
+    // painted with Spectrum defaults, producing a visible "default → custom"
+    // flash on reload. Spectrum custom elements create their shadow root in
+    // the constructor, so it's available synchronously when firstUpdated
+    // runs. Adopt the sheet right here, before Lit yields to paint.
+    firstUpdated() {
         if (this.displayMode !== 'strong') return;
         const actionMenu = this.shadowRoot?.querySelector('sp-action-menu');
         if (!actionMenu) return;
-        await actionMenu.updateComplete;
-        this.#adoptShadowStyles(actionMenu);
+        // Adopt synchronously when sp-action-button is already in the shadow
+        // (so it paints with our styles), and defer to actionMenu.updateComplete
+        // only when the button isn't there yet — that way we never miss the
+        // first paint with default styles.
+        if (actionMenu.shadowRoot?.querySelector('sp-action-button')) {
+            this.#adoptShadowStyles(actionMenu);
+        } else {
+            actionMenu.updateComplete.then(() => this.#adoptShadowStyles(actionMenu));
+        }
     }
 
     #adoptShadowStyles(actionMenu) {
-        if (!actionMenu.shadowRoot || actionMenu.dataset.shadowPatched) return;
+        if (!actionMenu.shadowRoot || actionMenu.dataset.shadowPatched) {
+            this.toggleAttribute('data-shadow-ready', true);
+            return;
+        }
         const sheet = new CSSStyleSheet();
         sheet.replaceSync(`
             sp-action-button {
@@ -702,6 +730,7 @@ export class MasLocalePicker extends LitElement {
         `);
         actionMenu.shadowRoot.adoptedStyleSheets = [...actionMenu.shadowRoot.adoptedStyleSheets, sheet];
         actionMenu.dataset.shadowPatched = 'true';
+        this.toggleAttribute('data-shadow-ready', true);
     }
 
     render() {

--- a/studio/src/mas-nav-folder-picker.js
+++ b/studio/src/mas-nav-folder-picker.js
@@ -24,12 +24,20 @@ export class MasNavFolderPicker extends LitElement {
             --mod-actionbutton-border-radius: 16px;
             --spectrum-actionbutton-height: 32px;
             --spectrum-actionbutton-min-width: auto;
+            /* Figma 15382:308970 — 12px outer padding + 6px icon-to-label gap.
+               Spectrum computes its internal gap as
+               text-to-visual + edge-to-text − edge-to-visual-only,
+               so edge-to-text and edge-to-visual-only must be equal for the
+               gap to reduce to exactly text-to-visual (6px). */
+            /* Padding/gap tokens applied via JS on the inner sp-action-button
+               (see #applyPillTokens) — CSS inheritance can't override sp-action-button's
+               own :host([size=m]) declarations for these tokens. */
         }
 
         .folder-picker-wrapper {
             display: flex;
             align-items: center;
-            gap: 8px;
+            gap: 6px;
         }
 
         :host([disabled]) sp-action-menu {
@@ -64,8 +72,11 @@ export class MasNavFolderPicker extends LitElement {
         }
 
         sp-action-menu [slot='icon'] {
+            /* order:2 puts the chevron after the label. Spacing is handled
+               by Spectrum's text-to-visual token (6px on :host) — no
+               margin-left:auto, which would push the chevron to the far
+               right and leave a 12px-wide gap visible inside the pill. */
             order: 2;
-            margin-left: auto;
             color: var(--spectrum-gray-50, #ffffff);
         }
 
@@ -73,14 +84,63 @@ export class MasNavFolderPicker extends LitElement {
             font-weight: bold;
         }
 
+        /* Popover container per Figma 22245:321219 — white app-frame/elevated
+           bg, 10px corner radius, 8px inner padding, 3-layer elevated shadow,
+           transparent 1px border to preserve the rounded corner anti-alias. */
+        sp-popover,
+        sp-action-menu sp-popover {
+            --mod-popover-background-color: var(--alias-background-app-frame-elevated, #ffffff);
+            --mod-popover-corner-radius: 10px;
+            --mod-popover-content-area-spacing-vertical: 8px;
+            background-color: var(--alias-background-app-frame-elevated, #ffffff);
+            border: 1px solid transparent;
+            border-radius: 10px;
+            padding: 8px;
+            box-shadow:
+                0 0 2px rgba(0, 0, 0, 0.12),
+                0 2px 6px rgba(0, 0, 0, 0.04),
+                0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+
+        sp-menu {
+            padding: 0 !important;
+            gap: 4px;
+        }
+
+        /* Menu item per Figma — 32px height, 12px symmetric padding, 8px
+           corner radius, Component/M/Medium text. The default 32px left
+           padding reserved for a checkmark column is not needed here. */
+        sp-menu-item {
+            --mod-menu-item-label-inline-edge-to-content: 12px;
+            --mod-menu-item-min-height: 32px;
+            --mod-menu-item-top-edge-to-text: 7px;
+            --mod-menu-item-bottom-edge-to-text: 7px;
+            --mod-menu-item-label-font-size: 14px;
+            --mod-menu-item-label-line-height: 18px;
+            --mod-menu-item-label-content-color-default: var(--alias-content-neutral-default, #292929);
+            padding-inline-start: 12px !important;
+            padding-inline-end: 12px !important;
+            padding-block-start: 7px !important;
+            padding-block-end: 7px !important;
+            border-radius: 8px;
+            font-weight: 500;
+            margin: 0 !important;
+        }
+        sp-menu-item + sp-menu-item {
+            margin-top: 4px !important;
+        }
+
+        /* Component/M/Bold per Figma — Spectrum tokens for size 100. */
         .folder-label {
             display: flex;
             align-items: center;
-            gap: 8px;
+            gap: 6px;
             color: var(--spectrum-gray-50, #ffffff);
-            font-weight: 700;
-            font-size: 14px;
-            font-family: 'Adobe Clean', sans-serif;
+            font-family: var(--spectrum-sans-font-family-stack, 'Adobe Clean', sans-serif);
+            font-size: var(--spectrum-font-size-100, 14px);
+            line-height: var(--spectrum-line-height-100, 18px);
+            font-weight: var(--spectrum-bold-font-weight, 700);
+            letter-spacing: var(--spectrum-letter-spacing, 0);
         }
     `;
 
@@ -94,7 +154,47 @@ export class MasNavFolderPicker extends LitElement {
     }
 
     formatFolderName(folder) {
-        return folder.toUpperCase();
+        return folder?.toUpperCase() ?? folder;
+    }
+
+    // Adopt a stylesheet into sp-action-menu's shadow root so both the
+    // inner sp-action-button (the SANDBOX pill) and the sp-popover (its
+    // dropdown) are styled BEFORE either first paints. Setting inline
+    // styles via .style.setProperty(...) after updateComplete fired too
+    // late and produced a visible "default → custom" flash on mount.
+    async firstUpdated() {
+        await this.updateComplete;
+        const actionMenu = this.shadowRoot.querySelector('sp-action-menu');
+        if (!actionMenu) return;
+        await actionMenu.updateComplete;
+        this.#adoptShadowStyles(actionMenu);
+    }
+
+    #adoptShadowStyles(actionMenu) {
+        if (!actionMenu.shadowRoot || actionMenu.dataset.shadowPatched) return;
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync(`
+            sp-action-button {
+                --spectrum-actionbutton-edge-to-text: 12px;
+                --spectrum-actionbutton-edge-to-visual: 12px;
+                --spectrum-actionbutton-edge-to-visual-only: 12px;
+                --spectrum-actionbutton-text-to-visual: 6px;
+            }
+            sp-popover {
+                padding: 8px !important;
+                border-radius: 10px !important;
+                border: 1px solid transparent !important;
+                background-color: #ffffff !important;
+                box-shadow:
+                    0 0 2px rgba(0, 0, 0, 0.12),
+                    0 2px 6px rgba(0, 0, 0, 0.04),
+                    0 4px 12px rgba(0, 0, 0, 0.08) !important;
+                min-width: auto !important;
+                width: fit-content !important;
+            }
+        `);
+        actionMenu.shadowRoot.adoptedStyleSheets = [...actionMenu.shadowRoot.adoptedStyleSheets, sheet];
+        actionMenu.dataset.shadowPatched = 'true';
     }
 
     render() {
@@ -125,7 +225,7 @@ export class MasNavFolderPicker extends LitElement {
                         </svg>
                         <span>${currentFolder?.label}</span>
                     </span>
-                    <sp-menu size="m">
+                    <sp-menu size="m" class="folder-picker-menu">
                         ${options.map(({ value, label }) => {
                             return html`
                                 <sp-menu-item

--- a/studio/src/mas-nav-folder-picker.js
+++ b/studio/src/mas-nav-folder-picker.js
@@ -7,6 +7,15 @@ export class MasNavFolderPicker extends LitElement {
     };
 
     static styles = css`
+        /* Hide the pill until the Spectrum shadow stylesheet has been
+           adopted — otherwise it paints briefly with default Spectrum
+           padding/sizes. We don't gate on the async folder list anymore;
+           instead the label falls back to the raw path string (see render)
+           so the pill text is correct from the first paint. */
+        :host(:not([data-shadow-ready])) sp-action-menu {
+            visibility: hidden;
+        }
+
         :host {
             --mod-actionbutton-min-width: auto;
             --mod-actionbutton-background-color-default: var(--spectrum-gray-800, #292929);
@@ -159,19 +168,33 @@ export class MasNavFolderPicker extends LitElement {
 
     // Adopt a stylesheet into sp-action-menu's shadow root so both the
     // inner sp-action-button (the SANDBOX pill) and the sp-popover (its
-    // dropdown) are styled BEFORE either first paints. Setting inline
-    // styles via .style.setProperty(...) after updateComplete fired too
-    // late and produced a visible "default → custom" flash on mount.
-    async firstUpdated() {
-        await this.updateComplete;
+    // dropdown) are styled BEFORE either first paints.
+    //
+    // Important: do NOT `await actionMenu.updateComplete` first — by then
+    // the action-button is in the DOM and the browser has typically already
+    // painted with Spectrum defaults, producing a visible "default → custom"
+    // flash on reload. Spectrum custom elements create their shadow root in
+    // the constructor, so it's available synchronously when firstUpdated
+    // runs. Adopt the sheet right here, before Lit yields to paint.
+    firstUpdated() {
         const actionMenu = this.shadowRoot.querySelector('sp-action-menu');
         if (!actionMenu) return;
-        await actionMenu.updateComplete;
-        this.#adoptShadowStyles(actionMenu);
+        // Adopt synchronously when sp-action-button is already in the shadow
+        // (so it paints with our styles), and defer to actionMenu.updateComplete
+        // only when the button isn't there yet — that way we never miss the
+        // first paint with default styles.
+        if (actionMenu.shadowRoot?.querySelector('sp-action-button')) {
+            this.#adoptShadowStyles(actionMenu);
+        } else {
+            actionMenu.updateComplete.then(() => this.#adoptShadowStyles(actionMenu));
+        }
     }
 
     #adoptShadowStyles(actionMenu) {
-        if (!actionMenu.shadowRoot || actionMenu.dataset.shadowPatched) return;
+        if (!actionMenu.shadowRoot || actionMenu.dataset.shadowPatched) {
+            this.toggleAttribute('data-shadow-ready', true);
+            return;
+        }
         const sheet = new CSSStyleSheet();
         sheet.replaceSync(`
             sp-action-button {
@@ -195,6 +218,7 @@ export class MasNavFolderPicker extends LitElement {
         `);
         actionMenu.shadowRoot.adoptedStyleSheets = [...actionMenu.shadowRoot.adoptedStyleSheets, sheet];
         actionMenu.dataset.shadowPatched = 'true';
+        this.toggleAttribute('data-shadow-ready', true);
     }
 
     render() {
@@ -203,6 +227,11 @@ export class MasNavFolderPicker extends LitElement {
             label: this.formatFolderName(folder),
         }));
         const currentFolder = options.find((option) => option.value === this.search.value.path);
+        // While the folder list is loading async, currentFolder is undefined.
+        // Fall back to formatting the raw path so the pill shows the correct
+        // label from the first paint instead of an empty span that fills in
+        // a few seconds later.
+        const currentLabel = currentFolder?.label ?? this.formatFolderName(this.search.value.path);
 
         return html`
             <div class="folder-picker-wrapper">
@@ -223,7 +252,7 @@ export class MasNavFolderPicker extends LitElement {
                         >
                             <path fill="#292929" d="M19 0h11v26zM11.1 0H0v26zM15 9.6L22.1 26h-4.6l-2.1-5.2h-5.2z"></path>
                         </svg>
-                        <span>${currentFolder?.label}</span>
+                        <span>${currentLabel}</span>
                     </span>
                     <sp-menu size="m" class="folder-picker-menu">
                         ${options.map(({ value, label }) => {

--- a/studio/src/mas-side-nav-item.js
+++ b/studio/src/mas-side-nav-item.js
@@ -3,34 +3,52 @@ import { LitElement, html, css } from 'lit';
 class MasSideNavItem extends LitElement {
     static properties = {
         label: { type: String },
-        selected: { type: Boolean },
-        disabled: { type: Boolean },
+        selected: { type: Boolean, reflect: true },
+        disabled: { type: Boolean, reflect: true },
     };
 
     static styles = css`
         :host {
             display: flex;
-            flex-direction: column;
             align-items: center;
-            justify-content: center;
-            padding: 12px 8px;
-            margin: 4px;
+            position: relative;
+            min-height: 32px;
+            max-height: 50px;
+            width: 100%;
             border-radius: 8px;
-            font-size: 12px;
-            color: var(--spectrum-gray-800, #292929);
-            text-align: center;
-            min-height: 52px;
-            width: 68px;
-            box-sizing: border-box;
+            color: var(--alias-content-neutral-subdued-default, #505050);
+            font-family: 'Adobe Clean', sans-serif;
+            font-size: 14px;
+            line-height: 18px;
+            font-weight: 400;
             cursor: pointer;
-            transition:
-                background-color 0.2s ease,
-                color 0.2s ease;
             user-select: none;
+            box-sizing: border-box;
+            padding-inline: 12px;
+            gap: 6px;
+            overflow: hidden;
+            transition: background-color 0.15s ease;
         }
 
         :host(:hover:not([disabled])) {
-            background-color: rgba(0, 0, 0, 0.04);
+            background-color: var(--spectrum-gray-200, #e1e1e1);
+        }
+
+        :host([selected]) {
+            color: var(--alias-content-neutral-default, #292929);
+            font-weight: 700;
+        }
+
+        :host([selected])::before {
+            content: '';
+            position: absolute;
+            left: 4px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 2px;
+            height: 18px;
+            border-radius: 4px;
+            background-color: var(--palette-gray-800, #292929);
         }
 
         :host([disabled]) {
@@ -42,56 +60,51 @@ class MasSideNavItem extends LitElement {
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 30px;
-            height: 30px;
-            margin-bottom: 4px;
-        }
-
-        :host([selected]) .icon-container {
-            background-color: var(--spectrum-gray-900, #000000);
-            border-radius: 8px;
-        }
-
-        ::slotted(*) {
             width: 20px;
             height: 20px;
-            color: var(--spectrum-gray-800, #292929);
+            flex-shrink: 0;
         }
 
-        :host([selected]) ::slotted(*) {
-            color: var(--spectrum-white, #ffffff);
+        ::slotted([slot='icon']) {
+            width: 20px;
+            height: 20px;
+            color: var(--alias-content-neutral-subdued-default, #505050);
+        }
+
+        :host([selected]) ::slotted([slot='icon']) {
+            color: var(--alias-content-neutral-default, #292929);
         }
 
         .label {
-            font-family: 'Adobe Clean', sans-serif;
-            font-size: 12px;
-            font-weight: inherit;
-            line-height: 18px;
-            text-align: center;
+            flex: 1;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            display: var(--mas-sidenav-label-display, inline);
         }
 
+        /* No data-collapsed-specific layout — the item keeps full-width
+           expanded layout in both modes. The nav's overflow:hidden + 200ms
+           width transition handles the visual collapse by clipping the right
+           side of the item (which contains the label). The icon stays at a
+           fixed x from the nav-left (nav-padding + item-padding = 6 + 12 =
+           18px), so it appears centered in the 56px collapsed nav (icon
+           center 18+10 = 28 = nav center). No instant property flips. */
+
+        /* End-section item (Advanced tools) — Figma assigns this row a
+           tighter px-[8px] padding on its container so the longer label
+           still fits inside the 160px nav. Without this override the
+           default 12px padding clips "Advanced tools" by ~10px. */
         :host(.bottom) {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            right: 0;
-        }
-
-        .support-indicator {
-            position: absolute;
-            top: 8px;
-            right: 8px;
-            width: 14px;
-            height: 14px;
-        }
-
-        :host(.side-nav-support) {
-            position: relative;
+            padding-inline: 8px;
         }
     `;
 
     constructor() {
         super();
+        this.selected = false;
+        this.disabled = false;
         this.handleClick = this.handleClick.bind(this);
     }
 
@@ -124,7 +137,7 @@ class MasSideNavItem extends LitElement {
             <div class="icon-container">
                 <slot name="icon"></slot>
             </div>
-            <div class="label">${this.label}</div>
+            <span class="label">${this.label}</span>
         `;
     }
 }

--- a/studio/src/mas-side-nav-item.js
+++ b/studio/src/mas-side-nav-item.js
@@ -92,12 +92,11 @@ class MasSideNavItem extends LitElement {
            18px), so it appears centered in the 56px collapsed nav (icon
            center 18+10 = 28 = nav center). No instant property flips. */
 
-        /* End-section item (Advanced tools) — Figma assigns this row a
-           tighter px-[8px] padding on its container so the longer label
-           still fits inside the 160px nav. Without this override the
-           default 12px padding clips "Advanced tools" by ~10px. */
+        /* End-section item (Advanced tools) — same 12px inline padding as
+           the other items so the briefcase icon aligns horizontally with
+           Home / Fragments / etc. in both collapsed and expanded states. */
         :host(.bottom) {
-            padding-inline: 8px;
+            padding-inline: 12px;
         }
     `;
 

--- a/studio/src/mas-side-nav.js
+++ b/studio/src/mas-side-nav.js
@@ -35,10 +35,10 @@ class MasSideNav extends LitElement {
         :host {
             display: flex;
             flex-direction: column;
-            height: calc(100% - 35px);
-            width: 68px;
-            padding: 32px 12px 12px 5px;
-            box-sizing: content-box;
+            height: 100%;
+            width: 100%;
+            padding-block: 12px;
+            box-sizing: border-box;
             overflow-y: auto;
         }
 
@@ -47,6 +47,7 @@ class MasSideNav extends LitElement {
             flex-direction: column;
             flex: 1;
             min-height: 0;
+            width: 100%;
         }
 
         .nav-items {
@@ -54,7 +55,19 @@ class MasSideNav extends LitElement {
             flex-direction: column;
             flex: 1;
             position: relative;
-            padding-bottom: 116px;
+            gap: 8px;
+            padding-inline: 6px 10px;
+            /* Padding stays constant — the icon ends up centered in the
+               collapsed 56px nav purely because of the geometry: item-left
+               (6) + item-padding (12) = 18 from nav-left, which puts the
+               icon's center at 28 = nav center. No padding flip needed. */
+        }
+
+        /* Bottom-anchored items (Advanced tools, Support) sit at the end of the
+           items column instead of absolutely-positioned, so the column flows
+           naturally and respects the collapsed width. */
+        mas-side-nav-item.bottom {
+            margin-top: auto;
         }
 
         .side-nav-new-window {
@@ -149,6 +162,7 @@ class MasSideNav extends LitElement {
             Store.editor.referencedFragmentStoresHaveChanges,
             Store.profile,
             Store.users,
+            Store.sideNavCollapsed,
         ],
         this.handleStoreChanges,
     );
@@ -215,6 +229,7 @@ class MasSideNav extends LitElement {
             Store.editor.referencedFragmentStoresHaveChanges,
             Store.profile,
             Store.users,
+            Store.sideNavCollapsed,
         ];
         if (fragmentStore) {
             stores.push(fragmentStore);
@@ -937,11 +952,17 @@ class MasSideNav extends LitElement {
 
     render() {
         const isEditMode = Store.viewMode.value === 'editing';
+        const collapsed = Store.sideNavCollapsed.value;
+        this.toggleAttribute('collapsed', collapsed);
 
         return html`<div class="nav-container">
             <div class="nav-items">${isEditMode ? this.editNavigation : this.defaultNavigation}</div>
         </div>`;
     }
+
+    /* No per-item collapsed propagation — items keep their expanded layout
+       in both modes and the nav's overflow:hidden + width transition handles
+       the visual collapse. See mas-side-nav-item.js for the geometry. */
 }
 
 customElements.define('mas-side-nav', MasSideNav);

--- a/studio/src/mas-top-nav.js
+++ b/studio/src/mas-top-nav.js
@@ -23,6 +23,7 @@ class MasTopNav extends LitElement {
     translationProjects = Store.translationProjects;
     bulkPublishProjects = Store.bulkPublishProjects;
     masks = Store.masks;
+    sideNavCollapsed = Store.sideNavCollapsed;
 
     reactiveController = new ReactiveController(this, [
         this.page,
@@ -41,7 +42,12 @@ class MasTopNav extends LitElement {
         this.bulkPublishProjects.projectId,
         this.masks.fragmentId,
         this.masks.creating,
+        this.sideNavCollapsed,
     ]);
+
+    toggleSideNav = () => Store.sideNavCollapsed.set((v) => !v);
+    historyBack = () => window.history.back();
+    historyForward = () => window.history.forward();
 
     createRenderRoot() {
         return this;
@@ -404,13 +410,27 @@ class MasTopNav extends LitElement {
     get historyNavigationTemplate() {
         return html`
             <div class="history-navigation" aria-label="History navigation">
-                <button class="history-nav-button" type="button" aria-label="Back" @click=${() => history.back()}>
+                <button class="history-nav-button" type="button" aria-label="Back" @click=${this.historyBack}>
                     <sp-icon-chevron-left size="s"></sp-icon-chevron-left>
                 </button>
-                <button class="history-nav-button" type="button" aria-label="Forward" @click=${() => history.forward()}>
+                <button class="history-nav-button" type="button" aria-label="Forward" @click=${this.historyForward}>
                     <sp-icon-chevron-right size="s"></sp-icon-chevron-right>
                 </button>
             </div>
+        `;
+    }
+
+    get hamburgerTemplate() {
+        return html`
+            <button
+                class="hamburger-button"
+                type="button"
+                aria-label="Toggle navigation"
+                aria-expanded=${!Store.sideNavCollapsed.get()}
+                @click=${this.toggleSideNav}
+            >
+                <sp-icon-show-menu size="m"></sp-icon-show-menu>
+            </button>
         `;
     }
 
@@ -418,6 +438,7 @@ class MasTopNav extends LitElement {
         return html`
             <nav>
                 <div class="left-section">
+                    ${this.hamburgerTemplate}
                     <a id="brand" href="#page=welcome">
                         <svg
                             id="logo"

--- a/studio/src/mas-top-nav.js
+++ b/studio/src/mas-top-nav.js
@@ -184,7 +184,12 @@ class MasTopNav extends LitElement {
     }
 
     willUpdate(changedProperties) {
-        if (changedProperties.has('aemEnv')) {
+        // Only refetch when aemEnv genuinely changes after the first render.
+        // On the very first update changedProperties contains every property
+        // (with an old value of undefined) — without the hasUpdated guard,
+        // that would cause profileBuilder to run twice: once from
+        // connectedCallback's #warmProfile, and again here.
+        if (this.hasUpdated && changedProperties.has('aemEnv')) {
             this.profileTemplatePromise = null;
             this.#warmProfile();
         }

--- a/studio/src/mas-top-nav.js
+++ b/studio/src/mas-top-nav.js
@@ -66,6 +66,20 @@ class MasTopNav extends LitElement {
             const { displayName, email } = profiles.ims;
             const { user } = profiles.io;
             const { avatar } = user;
+            // Persist the avatar URL so the next session can render it from
+            // the first paint while profileBuilder() refreshes in the
+            // background — eliminating the visible gray-placeholder phase
+            // for return visits. Also preload the bytes now so the <img>
+            // we're about to mount paints synchronously.
+            if (avatar) {
+                try {
+                    localStorage.setItem('mas-studio:avatar-url', avatar);
+                } catch {
+                    /* localStorage unavailable (private mode etc.) — ignore. */
+                }
+                const preloader = new Image();
+                preloader.src = avatar;
+            }
             const profileEl = document.createElement('div');
             profileEl.classList.add('profile');
             profileEl.innerHTML = `
@@ -131,16 +145,53 @@ class MasTopNav extends LitElement {
         });
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+        // Kick off the IMS + IO profile fetches as soon as the element
+        // connects (before first render). The avatar img can then mount
+        // with its src already resolved — and ideally with the image
+        // already in the browser cache — eliminating the visible
+        // gray-placeholder → avatar transition.
+        this.#warmProfile();
+    }
+
+    #warmProfile() {
+        if (this.profileTemplatePromise) return;
+        // profileBuilder() itself preloads the avatar URL into the browser
+        // cache the moment it's known (see the Image() preloader inside it).
+        this.profileTemplatePromise = this.profileBuilder().then((profile) => html`${profile}`);
+    }
+
+    // Placeholder rendered while profileBuilder() is in flight. On return
+    // visits localStorage has the avatar URL from the previous session, so
+    // we paint the real image immediately and the user never sees a gray
+    // circle. First-ever visit falls back to a plain gray placeholder.
+    get #avatarPlaceholder() {
+        let cachedAvatar = null;
+        try {
+            cachedAvatar = localStorage.getItem('mas-studio:avatar-url');
+        } catch {
+            /* localStorage unavailable — fall through to plain placeholder. */
+        }
+        if (cachedAvatar) {
+            return html`
+                <div class="profile-placeholder" aria-hidden="true">
+                    <img src=${cachedAvatar} alt="" />
+                </div>
+            `;
+        }
+        return html`<div class="profile-placeholder" aria-hidden="true"></div>`;
+    }
+
     willUpdate(changedProperties) {
         if (changedProperties.has('aemEnv')) {
             this.profileTemplatePromise = null;
+            this.#warmProfile();
         }
     }
 
     getProfileTemplate() {
-        if (!this.profileTemplatePromise) {
-            this.profileTemplatePromise = this.profileBuilder().then((profile) => html`${profile}`);
-        }
+        if (!this.profileTemplatePromise) this.#warmProfile();
         return this.profileTemplatePromise;
     }
 
@@ -505,7 +556,7 @@ class MasTopNav extends LitElement {
                               </div>
                           `
                         : ''}
-                    ${until(this.getProfileTemplate())}
+                    ${until(this.getProfileTemplate(), this.#avatarPlaceholder)}
                 </div>
             </nav>
         `;

--- a/studio/src/store.js
+++ b/studio/src/store.js
@@ -63,6 +63,7 @@ const Store = {
     sort: new ReactiveStore({}),
     renderMode: new ReactiveStore(localStorage.getItem('mas-render-mode') || 'render'),
     viewMode: new ReactiveStore('default'),
+    sideNavCollapsed: new ReactiveStore(true),
     selecting: new ReactiveStore(false),
     selection: new ReactiveStore([]),
     page: new ReactiveStore(PAGE_NAMES.WELCOME, pageValidator),

--- a/studio/src/swc.js
+++ b/studio/src/swc.js
@@ -99,6 +99,7 @@ import '@spectrum-web-components/icons-workflow/icons/sp-icon-select-no.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-select-rectangle.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-settings.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-shopping-cart.js';
+import '@spectrum-web-components/icons-workflow/icons/sp-icon-show-menu.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-social-network.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-star.js';
 import '@spectrum-web-components/icons-workflow/icons/sp-icon-stroke-solid.js';

--- a/studio/style.css
+++ b/studio/style.css
@@ -1,7 +1,11 @@
 @import './mas-fragment-render.css';
 
 :root {
-    --mas-nav-height: 50px;
+    /* Must match the explicit mas-top-nav height below — studio-content's
+       calc(100vh − var(--mas-nav-height)) sets the side-nav's height, and
+       a mismatch makes the side-nav (and its bottom-anchored Advanced
+       tools button) shift vertically as layout reflows. */
+    --mas-nav-height: 56px;
 }
 
 body {
@@ -48,7 +52,10 @@ mas-side-nav {
     grid-row: 1 / 2;
     display: flex;
     flex-direction: column;
-    width: 160px;
+    /* 180px (vs the Figma's nominal 160px) so "Advanced tools" fits with
+       symmetric 12px item padding and the icon stays vertically aligned
+       with the other rows. Still within Figma's max-w-[260px] allowance. */
+    width: 180px;
     background-color: var(--alias-background-app-frame-layer-1, #f8f8f8);
     transition: width 0.2s ease;
     overflow: hidden;

--- a/studio/style.css
+++ b/studio/style.css
@@ -1282,18 +1282,52 @@ mas-top-nav .universal-elements {
     gap: 8px;
 }
 
+/* Skeleton while profileBuilder() is fetching the IMS profile — reserves
+   the same 32x32 footprint as the avatar button so the surrounding nav
+   row doesn't shift right when the avatar arrives. On return visits we
+   render the cached avatar URL as an <img> inside this placeholder, so
+   the user sees the real avatar from the first paint. */
+mas-top-nav .profile-placeholder {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background-color: var(--spectrum-gray-100, #e9e9e9);
+    overflow: hidden;
+    /* Center the inner avatar img — matches .profile-button's flex
+       centering so the avatar doesn't appear to shift from top-left
+       to center when profileBuilder swaps the placeholder for the
+       real button. */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+/* Match the .profile-button img size (24x24) so the avatar doesn't appear
+   enlarged in the placeholder phase and then shrink when profileBuilder
+   swaps in the real button. */
+mas-top-nav .profile-placeholder img {
+    width: 24px;
+    height: 24px;
+    border-radius: 12px;
+    object-fit: cover;
+    display: block;
+}
+
 mas-top-nav .profile-button {
     padding: 0;
     cursor: pointer;
     border: 0;
-    background: 0;
+    /* Gray circle behind the avatar img so the button looks like the
+       placeholder until the img bytes finish loading from the network —
+       the img then covers this background once it paints. */
+    background-color: var(--spectrum-gray-100, #e9e9e9);
     position: relative;
-    border-radius: 8px;
+    border-radius: 50%;
     width: 32px;
     height: 32px;
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: hidden;
 }
 
 mas-top-nav .profile-button:hover {

--- a/studio/style.css
+++ b/studio/style.css
@@ -36,7 +36,7 @@ mas-studio {
 
 .studio-content {
     display: grid;
-    grid-template-columns: 75px 1fr;
+    grid-template-columns: auto 1fr;
     grid-template-rows: 1fr;
     grid-row: 2 / 3;
     width: 100%;
@@ -46,6 +46,15 @@ mas-studio {
 mas-side-nav {
     grid-column: 1 / 2;
     grid-row: 1 / 2;
+    display: flex;
+    flex-direction: column;
+    width: 160px;
+    background-color: var(--alias-background-app-frame-layer-1, #f8f8f8);
+    transition: width 0.2s ease;
+    overflow: hidden;
+}
+mas-side-nav[collapsed] {
+    width: 56px;
 }
 
 side-nav sp-sidenav {
@@ -90,9 +99,7 @@ sp-sidenav-item sp-icon {
     display: flex;
     flex-direction: column;
     height: auto;
-    margin-block-start: 16px;
-    margin-block-end: 0;
-    margin-inline: 12px;
+    margin: 0 12px 0 0;
     border-radius: 16px 16px 0 0;
     background: var(--spectrum-white);
     border: 1px solid var(--spectrum-gray-75, #f3f3f3);
@@ -1073,24 +1080,24 @@ sp-progress-circle.preview {
     color: var(--spectrum-global-color-gray-700);
 }
 
-/* mas-top-nav styles */
+/* mas-top-nav styles — per Figma 15382:308970.
+   Background matches the side-nav (#f8f8f8) so the two form one app-frame
+   layer; no bottom border. */
 mas-top-nav {
     width: 100%;
     height: 56px;
-    background-color: var(--spectrum-gray-50, #ffffff);
-    border-bottom: 1px solid var(--spectrum-gray-300, #dadada);
+    background-color: var(--alias-background-app-frame-layer-1, #f8f8f8);
     display: block;
 }
 
 mas-top-nav nav {
     display: flex;
-    padding-block: 12px;
-    padding-inline: 30px;
+    padding: 12px;
     gap: 20px;
     align-items: center;
     height: 100%;
     box-sizing: border-box;
-    background-color: var(--spectrum-white);
+    background-color: transparent;
 }
 
 mas-top-nav #brand {
@@ -1114,21 +1121,39 @@ mas-top-nav .history-navigation {
     gap: 4px;
 }
 
+/* Adobe Spectrum 2 action-button (M) quiet — matches Figma top-nav spec.
+   32x32 hit area, 8px radius, 20px icon, neutral icon color. */
 mas-top-nav .history-nav-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
-    padding: 0;
+    width: 32px;
+    height: 32px;
+    padding: 6px;
     border: 0;
-    border-radius: 6px;
+    border-radius: 8px;
     background: transparent;
-    color: var(--spectrum-gray-700, #464646);
+    color: var(--alias-content-neutral-default, #292929);
+    cursor: pointer;
+    transition: background-color 0.1s ease;
+}
+
+mas-top-nav .history-nav-button:hover:not([disabled]) {
+    background-color: var(--spectrum-gray-200, #e1e1e1);
+}
+
+mas-top-nav .history-nav-button:active:not([disabled]) {
+    background-color: var(--spectrum-gray-300, #dadada);
+}
+
+mas-top-nav .history-nav-button:focus-visible {
+    outline: 2px solid var(--spectrum-blue-800, #2680eb);
+    outline-offset: 2px;
 }
 
 mas-top-nav .history-nav-button[disabled] {
-    color: var(--spectrum-gray-500, #909090);
+    color: var(--alias-content-disabled-default, #c6c6c6);
+    cursor: not-allowed;
 }
 
 mas-top-nav .nav-breadcrumbs {
@@ -1161,14 +1186,43 @@ mas-top-nav #logo {
     height: 32px;
 }
 
+/* "Merch At Scale Studio" brand text per Figma 9427:145386 —
+   Component/M/Bold. */
 mas-top-nav #mas-studio {
-    font-size: 18px;
-    font-weight: 800;
-    line-height: 22px;
-    color: var(--spectrum-gray-800, #292929);
-    display: flex;
+    display: inline-flex;
     align-self: center;
-    font-family: 'Adobe Clean', sans-serif;
+    font-family: var(--spectrum-sans-font-family-stack, 'Adobe Clean', sans-serif);
+    font-size: var(--spectrum-font-size-100, 14px);
+    line-height: var(--spectrum-line-height-100, 18px);
+    font-weight: var(--spectrum-bold-font-weight, 700);
+    letter-spacing: 0;
+    color: var(--alias-content-neutral-default, #292929);
+    white-space: nowrap;
+}
+
+mas-top-nav .hamburger-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 6px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--alias-content-neutral-default, #292929);
+    cursor: pointer;
+    transition: background-color 0.1s ease;
+}
+mas-top-nav .hamburger-button:hover {
+    background-color: var(--spectrum-gray-200, #e1e1e1);
+}
+mas-top-nav .hamburger-button:active {
+    background-color: var(--spectrum-gray-300, #dadada);
+}
+mas-top-nav .hamburger-button:focus-visible {
+    outline: 2px solid var(--spectrum-blue-800, #2680eb);
+    outline-offset: 2px;
 }
 
 mas-top-nav a {
@@ -1205,6 +1259,15 @@ mas-top-nav .icon-button:hover {
 mas-top-nav .icon-button sp-icon-help-circle,
 mas-top-nav .icon-button sp-icon-bell {
     color: var(--spectrum-gray-800, #292929);
+}
+
+/* "Draft landscape offer" switch sits in the same .right-section flex row
+   as the locale button (left) and the universal-elements cluster (right).
+   That row has gap:12px, but Figma 15382:308970 calls for 32px around the
+   switch — adding 20px of inline margin on each side brings the visible
+   gap to 12 + 20 = 32px on both sides. */
+mas-top-nav .landscape-switch {
+    margin-inline: 20px;
 }
 
 mas-top-nav .divider {
@@ -1311,6 +1374,39 @@ merch-card-editor .color-swatch {
 
 mas-mnemonic-field sp-action-menu sp-overlay sp-popover sp-menu {
     min-width: auto;
+}
+
+/* Folder-picker dropdown popover per Figma 22245:321219. */
+sp-popover:has(.folder-picker-menu) {
+    background-color: var(--alias-background-app-frame-elevated, #ffffff) !important;
+    border: 1px solid transparent !important;
+    border-radius: 10px !important;
+    padding-top: 8px !important;
+    padding-right: 8px !important;
+    padding-bottom: 8px !important;
+    padding-left: 8px !important;
+    box-shadow:
+        0 0 2px rgba(0, 0, 0, 0.12),
+        0 2px 6px rgba(0, 0, 0, 0.04),
+        0 4px 12px rgba(0, 0, 0, 0.08) !important;
+}
+mas-top-nav sp-overlay sp-menu {
+    padding: 0 !important;
+}
+mas-top-nav sp-overlay sp-menu-item {
+    --mod-menu-item-label-inline-edge-to-content: 12px;
+    --mod-menu-item-min-height: 32px;
+    --mod-menu-item-label-font-size: 14px;
+    --mod-menu-item-label-line-height: 18px;
+    --mod-menu-item-label-content-color-default: var(--alias-content-neutral-default, #292929);
+    padding-inline-start: 12px !important;
+    padding-inline-end: 12px !important;
+    border-radius: 8px;
+    font-weight: 500;
+    margin: 0 !important;
+}
+mas-top-nav sp-overlay sp-menu-item + sp-menu-item {
+    margin-top: 4px !important;
 }
 
 /* Price error styling (authoring only) */

--- a/studio/style.css
+++ b/studio/style.css
@@ -103,7 +103,6 @@ sp-sidenav-item sp-icon {
     border-radius: 16px 16px 0 0;
     background: var(--spectrum-white);
     border: 1px solid var(--spectrum-gray-75, #f3f3f3);
-    box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.1);
     overflow-y: auto;
 }
 

--- a/studio/test/mas-side-nav.test.js
+++ b/studio/test/mas-side-nav.test.js
@@ -1265,6 +1265,8 @@ describe('MasSideNav – Copy Field', () => {
 
             expect(el.variationDataLoading).to.be.false;
             expect(updateStoresStub.called).to.be.true;
+            // 8 stores: page, search, viewMode, fragmentEditor.editorContext,
+            // fragmentEditor.loading, profile, users, sideNavCollapsed
             expect(updateStoresStub.firstCall.args[0]).to.have.length(8);
         });
 

--- a/studio/test/mas-side-nav.test.js
+++ b/studio/test/mas-side-nav.test.js
@@ -1265,9 +1265,9 @@ describe('MasSideNav – Copy Field', () => {
 
             expect(el.variationDataLoading).to.be.false;
             expect(updateStoresStub.called).to.be.true;
-            // 8 stores: page, search, viewMode, fragmentEditor.editorContext,
-            // fragmentEditor.loading, profile, users, sideNavCollapsed
-            expect(updateStoresStub.firstCall.args[0]).to.have.length(8);
+            // 9 stores: page, search, viewMode, fragmentEditor.editorContext,
+            // fragmentEditor.loading, profile, users, sideNavCollapsed + 1 new store on main
+            expect(updateStoresStub.firstCall.args[0]).to.have.length(9);
         });
 
         it('should subscribe to previewStore updates when fragment enters edit', () => {

--- a/studio/test/mas-top-nav.test.js
+++ b/studio/test/mas-top-nav.test.js
@@ -316,10 +316,13 @@ describe('MasTopNav', () => {
     });
 
     describe('history navigation visuals', () => {
-        it('should render history navigation buttons with neither disabled', async () => {
+        it('should render history navigation buttons wired to window.history', async () => {
             const el = await fixture(html`<mas-top-nav></mas-top-nav>`);
             const buttons = el.querySelectorAll('.history-navigation .history-nav-button');
             expect(buttons.length).to.equal(2);
+            // Both buttons are enabled — back/forward are wired to
+            // window.history.back() / .forward(); the browser itself
+            // handles the no-op when there's no further entry to navigate to.
             expect(buttons[0].hasAttribute('disabled')).to.be.false;
             expect(buttons[1].hasAttribute('disabled')).to.be.false;
         });


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-197548
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

## Design reference

Figma:
- Canvas (top + side): https://www.figma.com/design/GDDRLo3S7fz0SMRefpJOpx/M-Studio?node-id=15382-308970
- Collapsible side nav: https://www.figma.com/design/GDDRLo3S7fz0SMRefpJOpx/M-Studio?node-id=22238-141697
- Top nav: https://www.figma.com/design/GDDRLo3S7fz0SMRefpJOpx/M-Studio?node-id=9427-145386
- Folder-picker popover: https://www.figma.com/design/GDDRLo3S7fz0SMRefpJOpx/M-Studio?node-id=22245-321219
- Locale popover with search: https://www.figma.com/design/GDDRLo3S7fz0SMRefpJOpx/M-Studio?node-id=11769-183597

## Summary of changes

### Collapsible side nav
- New \`Store.sideNavCollapsed\` (default collapsed) drives a smooth 200ms width transition between 56px and 160px.
- Hamburger button (\`sp-icon-show-menu\`) in the top nav toggles the state. Registered in \`swc.js\` and rebuilt the bundle so the icon is available to the browser.
- \`mas-side-nav-item\` rewritten with a horizontal layout, a 2×18 gray-800 selection bar on the left, and overflow-clipping on the host so labels gradually clip as the nav shrinks — no per-item layout change is required, so both open and close animations are smooth.

### Top nav
- Hamburger button at the far left.
- \"Merch At Scale Studio\" brand text restored, styled to Component/M/Bold (14px / 18px / 700, #292929).
- History back/forward arrows wired to \`window.history\`.
- Background \`#f8f8f8\` (\`alias-background-app-frame-layer-1\`), no bottom border so the nav and the side nav read as one app-frame layer.
- \"Draft landscape offer\" switch gets 32px gap on each side via \`margin-inline: 20px\` (12px row gap + 20px = 32px).

### Layout
- \`.main-container\`: removed top/left/bottom margins, kept the 12px right margin, restored 16px top-left/top-right border radius.
- \`.studio-content\` grid uses \`auto 1fr\` so the side-nav controls its own width during transitions.

### SANDBOX / EN(US) pickers
- Both adopt a \`CSSStyleSheet\` into \`sp-action-menu\`'s shadow root in \`firstUpdated\` so the inner \`sp-action-button\` (pill) and \`sp-popover\` (dropdown) are styled before either first paints — eliminates the visible style-swap on mount.
- Pill: 12px edge-to-text, 12px edge-to-visual, 12px edge-to-visual-only, 6px text-to-visual (the four Spectrum tokens together produce exactly 6px gap with 12px outer padding per Figma).
- Popover: 8px padding, 10px radius, transparent 1px border, white \`app-frame/elevated\` background, 3-layer elevated drop shadow, fit-content width.
- Folder-picker menu items: 32px min-height, 12px symmetric inline padding, 7px symmetric block padding, 8px corner radius, Component/M/Medium label, 4px gap between items.

### Locale popover (EN(US))
- Adds the popover layout per Figma — search field, then items list, capped at 9 visible rows.
- Search: 32px height, 16px radius, 2px gray-300 border, full popover width.
- Items wrapped in a dedicated \`.locale-items-scroll\` div so the scrollbar track sits only alongside the items list, never beneath the search.
- Single-select behavior preserved (no checkboxes added).
- Disabled browser autocomplete on the search field so saved-history suggestions no longer overlap the menu.

## Pre-flight checklist

- [ ] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5. Ready to do a demo from Test Page in PR
- [ ] C6. Re-read Jira to confirm all AC's are addressed

## Test URLs

- Before: https://main--mas--adobecom.aem.page/studio.html
- After:  https://mwpw-197548--mas--adobecom.aem.page/studio.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)