### PR TITLE
MWPW-197564: Match settings overrides by request country

### DIFF
--- a/io/www/src/fragment/transformers/settings.js
+++ b/io/www/src/fragment/transformers/settings.js
@@ -1,5 +1,5 @@
 import { odinUrl, odinReferences } from '../utils/paths.js';
-import { fetch, getFragmentId, getRegionalLocale, getRequestInfos } from '../utils/common.js';
+import { fetch, getCountry, getFragmentId, getRegionalLocale, getRequestInfos } from '../utils/common.js';
 import { logDebug } from '../utils/log.js';
 
 const SETTINGS_ID_PATH = 'settings/index';
@@ -162,7 +162,7 @@ async function init(initContext) {
     return await getSettings(initContext);
 }
 
-export function resolveSettingEntry(fragment, locale, setting) {
+export function resolveSettingEntry(fragment, locale, setting, country) {
     const defaultEntry = setting.default;
     if (!defaultEntry) return null;
     const template = fragment.fields?.variant;
@@ -170,7 +170,10 @@ export function resolveSettingEntry(fragment, locale, setting) {
     const fragmentTags = fragment.fields?.tags ?? [];
     const filtered = setting.override.filter((overrideSetting) => {
         const localeOk =
-            !overrideSetting.locales || overrideSetting.locales.length === 0 || overrideSetting.locales.includes(locale);
+            !overrideSetting.locales ||
+            overrideSetting.locales.length === 0 ||
+            overrideSetting.locales.includes(locale) ||
+            (country && overrideSetting.locales.some((entryLocale) => entryLocale.split('_')[1]?.toUpperCase() === country));
         const tagsOk =
             !overrideSetting.tags ||
             overrideSetting.tags.length === 0 ||
@@ -195,8 +198,9 @@ export function resolveSettingEntry(fragment, locale, setting) {
 }
 
 function applySettings(context, fragment, locale, settings) {
+    const country = getCountry(context)?.toUpperCase();
     for (const key of Object.keys(settings)) {
-        const entry = resolveSettingEntry(fragment, locale, settings[key]);
+        const entry = resolveSettingEntry(fragment, locale, settings[key], country);
         if (!entry) continue;
         fragment.settings = {
             ...fragment.settings,

--- a/io/www/test/fragment/settings.test.js
+++ b/io/www/test/fragment/settings.test.js
@@ -835,6 +835,65 @@ describe('settings', () => {
                 expect(result.body.settings.displayAnnual).to.equal(false);
             });
 
+            it('applies en_AU override for a French request with country=AU', async () => {
+                const context = {
+                    locale: 'fr_FR',
+                    country: 'AU',
+                    body: { fields: {} },
+                    promises: {
+                        settings: Promise.resolve({
+                            displayAnnual: {
+                                default: { name: 'displayAnnual', valuetype: 'boolean', booleanValue: false },
+                                override: [
+                                    { name: 'displayAnnual', valuetype: 'boolean', locales: ['en_AU'], booleanValue: true },
+                                ],
+                            },
+                        }),
+                    },
+                };
+                const result = await settings.process(context);
+                expect(result.body.settings.displayAnnual).to.equal(true);
+            });
+
+            it('matches override country case-insensitively', async () => {
+                const context = {
+                    locale: 'fr_FR',
+                    country: 'au',
+                    body: { fields: {} },
+                    promises: {
+                        settings: Promise.resolve({
+                            displayAnnual: {
+                                default: { name: 'displayAnnual', valuetype: 'boolean', booleanValue: false },
+                                override: [
+                                    { name: 'displayAnnual', valuetype: 'boolean', locales: ['en_AU'], booleanValue: true },
+                                ],
+                            },
+                        }),
+                    },
+                };
+                const result = await settings.process(context);
+                expect(result.body.settings.displayAnnual).to.equal(true);
+            });
+
+            it('derives country from the locale when no country param is present', async () => {
+                const context = {
+                    locale: 'en_AU',
+                    body: { fields: {} },
+                    promises: {
+                        settings: Promise.resolve({
+                            displayAnnual: {
+                                default: { name: 'displayAnnual', valuetype: 'boolean', booleanValue: false },
+                                override: [
+                                    { name: 'displayAnnual', valuetype: 'boolean', locales: ['en_AU'], booleanValue: true },
+                                ],
+                            },
+                        }),
+                    },
+                };
+                const result = await settings.process(context);
+                expect(result.body.settings.displayAnnual).to.equal(true);
+            });
+
             it('normalizes fragment.fields boolean string "true" for boolean type (e.g. showPlanType)', async () => {
                 const context = {
                     locale: 'en_US',


### PR DESCRIPTION
AU users on non-English locales (e.g. French) kept AU pricing but lost the annualized ABM price, which AU law requires wherever an ABM price is shown. `displayAnnual` was gated by an `en_AU`-keyed settings override, so a `fr_FR` + `country=AU` request never matched and the flag fell back to `false`. `resolveSettingEntry` now also matches an override when the request country equals the country segment of one of its locale codes (`en_AU` → `AU`). Locale is left intact so locale-specific content overrides keep resolving correctly.

Resolves https://jira.corp.adobe.com/browse/MWPW-197564
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

- [x] C1. Cover code with Unit Tests (4 new tests, full suite 100% coverage)
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [x] C3. Verify all Checks are green (unit tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5. ready to demo from Test Page in PR
- [ ] C6. read Jira once more to validate all AC's addressed

Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-197564--mas--adobecom.aem.live/
