### PR TITLE
[MWPW-192902] - Point bizpro Nala specs at nala-folder seed cards so teardown cleans up clones

### DIFF
--- a/nala/studio/acom/bizpro/specs/bizpro_css.spec.js
+++ b/nala/studio/acom/bizpro/specs/bizpro_css.spec.js
@@ -6,9 +6,9 @@ export default {
             name: '@studio-bizpro-css',
             path: '/studio.html',
             data: {
-                cardid: '3004a00c-bec2-4944-90f0-914e0319b826',
+                cardid: '4f048713-13f8-410b-94a9-c0e03d09fc34',
             },
-            browserParams: '#page=content&path=sandbox&query=',
+            browserParams: '#page=content&path=nala&query=',
             tags: '@mas-studio @acom @acom-css @acom-bizpro @acom-bizpro-css',
         },
     ],

--- a/nala/studio/acom/bizpro/specs/bizpro_edit_and_discard.spec.js
+++ b/nala/studio/acom/bizpro/specs/bizpro_edit_and_discard.spec.js
@@ -6,9 +6,9 @@ export default {
             name: '@studio-bizpro-edit-discard-editor-fields',
             path: '/studio.html',
             data: {
-                cardid: '9fb5ce85-1a9e-46df-8982-485bd9019d3b',
+                cardid: '153bc964-d558-47ba-95b5-345fa8a02087',
             },
-            browserParams: '#page=fragment-editor&path=sandbox&fragmentId=',
+            browserParams: '#page=fragment-editor&path=nala&fragmentId=',
             tags: '@mas-studio @acom @acom-edit @acom-bizpro @acom-bizpro-edit',
         },
         {
@@ -16,12 +16,12 @@ export default {
             name: '@studio-bizpro-edit-discard-title',
             path: '/studio.html',
             data: {
-                cardid: '9fb5ce85-1a9e-46df-8982-485bd9019d3b',
+                cardid: '153bc964-d558-47ba-95b5-345fa8a02087',
                 title: {
                     updated: 'Edited BizPro Title',
                 },
             },
-            browserParams: '#page=fragment-editor&path=sandbox&fragmentId=',
+            browserParams: '#page=fragment-editor&path=nala&fragmentId=',
             tags: '@mas-studio @acom @acom-edit @acom-bizpro @acom-bizpro-edit',
         },
         {
@@ -29,12 +29,12 @@ export default {
             name: '@studio-bizpro-edit-discard-description',
             path: '/studio.html',
             data: {
-                cardid: '9fb5ce85-1a9e-46df-8982-485bd9019d3b',
+                cardid: '153bc964-d558-47ba-95b5-345fa8a02087',
                 description: {
                     updated: 'Edited BizPro description text',
                 },
             },
-            browserParams: '#page=fragment-editor&path=sandbox&fragmentId=',
+            browserParams: '#page=fragment-editor&path=nala&fragmentId=',
             tags: '@mas-studio @acom @acom-edit @acom-bizpro @acom-bizpro-edit',
         },
         {
@@ -44,12 +44,12 @@ export default {
             data: {
                 // individuals-1 — has authored whats-included sections, so the
                 // toggle renders and the label round-trips through serialize.
-                cardid: '3004a00c-bec2-4944-90f0-914e0319b826',
+                cardid: '4f048713-13f8-410b-94a9-c0e03d09fc34',
                 whatsIncluded: {
                     label: 'Edited toggle label:',
                 },
             },
-            browserParams: '#page=fragment-editor&path=sandbox&fragmentId=',
+            browserParams: '#page=fragment-editor&path=nala&fragmentId=',
             tags: '@mas-studio @acom @acom-edit @acom-bizpro @acom-bizpro-edit',
         },
     ],

--- a/nala/studio/acom/bizpro/specs/bizpro_save.spec.js
+++ b/nala/studio/acom/bizpro/specs/bizpro_save.spec.js
@@ -6,11 +6,11 @@ export default {
             name: '@studio-bizpro-save-edited-fields',
             path: '/studio.html',
             data: {
-                cardid: 'c3453a4e-cb16-4208-a1bb-fd56f170e0ab',
+                cardid: '6edac1ee-89f9-4432-aa42-008a360fa537',
                 title: 'Saved BizPro Title',
                 whatsIncludedLabel: 'Saved toggle label:',
             },
-            browserParams: '#page=fragment-editor&path=sandbox&fragmentId=',
+            browserParams: '#page=fragment-editor&path=nala&fragmentId=',
             tags: '@mas-studio @acom @acom-save @acom-bizpro @acom-bizpro-save',
         },
     ],


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-192902
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Test-infra fix, split out of #939 so it can merge independently.

The bizpro Nala tests clone their seed card before editing, and the clone is created in the same AEM folder as its source. The specs pointed at seed cards in the `sandbox` folder, but the global teardown only sweeps `path=nala` — so every run left orphaned `[runId]`-titled clones accumulating in `/content/dam/mas/sandbox/en_US`.

This repoints the three bizpro spec files (`bizpro_css`, `bizpro_edit_and_discard`, `bizpro_save`) at equivalent seed cards created in the `nala` folder (`path=sandbox` → `path=nala`, updated card IDs), so clones land where the teardown finds and deletes them.

Note: clones already orphaned in Sandbox by earlier runs are not removed by this change and need a one-time manual cleanup.

- [x] C1. Cover code with Unit Tests (n/a — Nala spec data only)
- [x] C2. Add a Nala test (changes the bizpro Nala specs themselves)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [x] C4. PR description contains working Test Page link where the feature can be tested
- [x] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## Test URLs:

- Seed cards: https://mwpw-192902-nala-seed-cards--mas--adobecom.aem.page/studio.html#page=content&path=nala&tags=mas%3Avariant%2Fbizpro
- Verify: run `@acom-bizpro` Nala tests and confirm teardown deletes the cloned fragments from the `nala` folder (no new clones in `sandbox`)