### PR TITLE
MWPW-198158: Match user email case-insensitively for Studio settings access

### DIFF
--- a/studio/src/groups.js
+++ b/studio/src/groups.js
@@ -22,7 +22,8 @@ function normalizeSurface(surface) {
 function getCurrentUserNormalizedGroups() {
     const { email } = Store.profile.get();
     if (!email) return null;
-    const user = Store.users.get().find((u) => u.userPrincipalName === email);
+    const normalizedEmail = email.toLowerCase();
+    const user = Store.users.get().find((u) => u.userPrincipalName?.toLowerCase() === normalizedEmail);
     if (!user) return null;
     return user.groups?.map((group) => group.toUpperCase()) ?? [];
 }

--- a/studio/test/groups.test.js
+++ b/studio/test/groups.test.js
@@ -51,6 +51,16 @@ describe('groups', () => {
         expect(canAccessSettings('/acom/extra')).to.be.true;
     });
 
+    it('canAccessSettings matches user email case-insensitively', () => {
+        Store.users.set([{ userPrincipalName: 'power.user@adobe.com', groups: ['GRP-ODIN-MAS-ACOM-CC-POWERUSERS'] }]);
+        Store.profile.set({ email: 'Power.User@adobe.com' });
+        expect(canAccessSettings('acom-cc')).to.be.true;
+
+        Store.users.set([{ userPrincipalName: 'Power.User@adobe.com', groups: ['GRP-ODIN-MAS-ACOM-CC-POWERUSERS'] }]);
+        Store.profile.set({ email: 'power.user@adobe.com' });
+        expect(canAccessSettings('acom-cc')).to.be.true;
+    });
+
     it('canAccessSettings is false without surface path', () => {
         Store.profile.set({ email: 'a@adobe.com' });
         Store.users.set([{ userPrincipalName: 'a@adobe.com', groups: ['GRP-ODIN-MAS-ACOM-POWERUSERS'] }]);


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-198158

Studio matched the IMS profile email to the cached userPrincipalName with a case-sensitive ===, so users whose IMS email casing differs never saw the Global settings card despite correct POWERUSERS group membership (reported on acom-cc). The lookup in groups.js now compares case-insensitively, covered by a unit test for both casing directions.

## Test URLs:

- Before: https://main--mas--adobecom.aem.live/studio.html
- After: https://mwpw-198158--mas--adobecom.aem.live/studio.html

## Checklist:

- [x] Code follows project conventions
- [x] Tests pass locally (groups + router suites)
- [x] Linter runs without errors
- [ ] Tested on Before/After URLs