### PR TITLE
MWPW-201030: Allow creating a promo variation without geos (inherit promo project's geos)

### DIFF
--- a/studio/src/promotions/mas-promo-variation-geos.css.js
+++ b/studio/src/promotions/mas-promo-variation-geos.css.js
@@ -53,6 +53,16 @@ export const styles = css`
         margin: 0;
     }
 
+    .inherit-hint {
+        color: var(--spectrum-gray-700, #505050);
+        font-size: 12px;
+        margin: 0;
+    }
+
+    .inherit-hint.blocked {
+        color: var(--spectrum-negative-color, #d7373f);
+    }
+
     :host([compact]) .select-geos-content {
         min-width: 220px;
         gap: 8px;

--- a/studio/src/promotions/mas-promo-variation-geos.js
+++ b/studio/src/promotions/mas-promo-variation-geos.js
@@ -7,6 +7,7 @@ class MasPromoVariationGeos extends LitElement {
     static properties = {
         geos: { type: Array },
         disabledGeos: { type: Array },
+        hasEmptyGeosVariation: { type: Boolean },
         value: { type: Array },
         compact: { type: Boolean, reflect: true },
         searchQuery: { type: String, state: true },
@@ -16,6 +17,7 @@ class MasPromoVariationGeos extends LitElement {
         super();
         this.geos = [];
         this.disabledGeos = [];
+        this.hasEmptyGeosVariation = false;
         this.value = [];
         this.compact = false;
         this.searchQuery = '';
@@ -43,6 +45,10 @@ class MasPromoVariationGeos extends LitElement {
         const count = this.value.length;
         if (count) return `${count} ${count === 1 ? 'geo' : 'geos'} selected`;
         return `${this.geos.length} ${this.geos.length === 1 ? 'geo' : 'geos'}`;
+    }
+
+    get showInheritHint() {
+        return this.value.length === 0;
     }
 
     emitChange(value) {
@@ -97,6 +103,13 @@ class MasPromoVariationGeos extends LitElement {
                                   </sp-checkbox>
                                   <span class="geo-count">${this.numberOfGeos}</span>
                               </div>
+                              ${this.showInheritHint
+                                  ? html`<p class="inherit-hint ${this.hasEmptyGeosVariation ? 'blocked' : ''}">
+                                        ${this.hasEmptyGeosVariation
+                                            ? 'A variation with no geos already exists for this project. Select one or more geos to continue.'
+                                            : 'No geos selected — this variation will apply to all geos, including any added later.'}
+                                    </p>`
+                                  : nothing}
                               <sp-divider size="s"></sp-divider>
                           `}
                 </div>

--- a/studio/src/promotions/mas-promotions-items-table.js
+++ b/studio/src/promotions/mas-promotions-items-table.js
@@ -481,9 +481,11 @@ class MasPromotionsItemsTable extends LitElement {
         createPromoVariationLoading: { type: Boolean, state: true },
         existingPromoVariationDefaultPaths: { type: Object, state: true },
         existingPromoVariationGeosByPath: { type: Object, state: true },
+        existingPromoVariationEmptyGeoPaths: { type: Object, state: true },
         promoVariationGeosDialogItem: { type: Object, state: true },
         promoVariationSelectedGeos: { type: Array, state: true },
         promoVariationDisabledGeos: { type: Array, state: true },
+        fragmentHasEmptyGeosVariation: { type: Boolean, state: true },
     };
 
     #loadedPathsKey = null;
@@ -499,9 +501,11 @@ class MasPromotionsItemsTable extends LitElement {
         this.createPromoVariationLoading = false;
         this.existingPromoVariationDefaultPaths = new Set();
         this.existingPromoVariationGeosByPath = new Map();
+        this.existingPromoVariationEmptyGeoPaths = new Set();
         this.promoVariationGeosDialogItem = null;
         this.promoVariationSelectedGeos = [];
         this.promoVariationDisabledGeos = [];
+        this.fragmentHasEmptyGeosVariation = false;
         this.promoCodeExceptions = [];
         this.defaultPromoCode = '';
         this.geos = [];
@@ -624,6 +628,13 @@ class MasPromotionsItemsTable extends LitElement {
 
     updated(changed) {
         super.updated(changed);
+        if (
+            changed.has('promoVariationGeosDialogItem') ||
+            changed.has('promoVariationSelectedGeos') ||
+            changed.has('fragmentHasEmptyGeosVariation')
+        ) {
+            this.#syncPromoVariationConfirmButtonDisabled();
+        }
         if (!this.type) return;
         if (this.type === TABLE_TYPE.OFFERS) {
             this.#loadSelectedOffers(this.selectedPaths);
@@ -692,12 +703,15 @@ class MasPromotionsItemsTable extends LitElement {
             if (signal.aborted) return;
             this.existingPromoVariationDefaultPaths = new Set();
             this.existingPromoVariationGeosByPath = new Map();
+            this.existingPromoVariationEmptyGeoPaths = new Set();
             return;
         }
         const previousPaths = this.existingPromoVariationDefaultPaths;
         const previousGeos = this.existingPromoVariationGeosByPath;
+        const previousEmptyGeoPaths = this.existingPromoVariationEmptyGeoPaths;
         const existingPaths = new Set();
         const geosByPath = new Map();
+        const emptyGeoPaths = new Set();
         await Promise.all(
             items.map(async (item) => {
                 if (signal.aborted) return;
@@ -706,17 +720,22 @@ class MasPromotionsItemsTable extends LitElement {
                     if (variations.length) {
                         existingPaths.add(item.path);
                         geosByPath.set(item.path, getUsedGeoTags(variations));
+                        if (variations.some((variation) => !variation.pznTags?.length)) {
+                            emptyGeoPaths.add(item.path);
+                        }
                     }
                 } catch {
                     if (previousPaths.has(item.path)) {
                         existingPaths.add(item.path);
                         geosByPath.set(item.path, previousGeos.get(item.path) || []);
+                        if (previousEmptyGeoPaths.has(item.path)) emptyGeoPaths.add(item.path);
                     }
                 }
             }),
         );
         if (signal.aborted) return;
         this.existingPromoVariationDefaultPaths = existingPaths;
+        this.existingPromoVariationEmptyGeoPaths = emptyGeoPaths;
         this.existingPromoVariationGeosByPath = geosByPath;
     }
 
@@ -781,47 +800,34 @@ class MasPromotionsItemsTable extends LitElement {
         if (isPromoVariationPath(item.path)) return false;
         if (!this.existingPromoVariationGeosByPath.has(item.path)) return true;
         const usedGeos = this.existingPromoVariationGeosByPath.get(item.path);
-        return this.#geoValues.some((geo) => !usedGeos.includes(geo));
-    }
-
-    #hasPromoVariationForItem(item) {
-        if (!item?.path || !this.#promotionTagId) return false;
-        if (isPromoVariationPath(item.path)) return false;
-        return this.existingPromoVariationDefaultPaths.has(item.path);
-    }
-
-    async #viewPromoVariation(e, item) {
-        e.stopPropagation();
-        const promoTag = this.#promotionTagId;
-        if (!this.repository?.aem) return;
-
-        let variations;
-        try {
-            variations = await probePromoVariationsForFragment(this.repository.aem, item.path, promoTag);
-        } catch {
-            showToast(PROMO_VARIATION_LOOKUP_FAILED_MESSAGE, 'negative');
-            return;
-        }
-        const variation = variations[0];
-        if (!variation?.id) {
-            showToast(PROMO_VARIATION_MISSING_MESSAGE, 'negative');
-            this.existingPromoVariationDefaultPaths = new Set(
-                [...this.existingPromoVariationDefaultPaths].filter((path) => path !== item.path),
-            );
-            return;
-        }
-
-        await this.#navigateToFragmentEditorFromProject(variation.id, variation.path);
+        const hasUnusedGeo = this.#geoValues.some((geo) => !usedGeos.includes(geo));
+        const hasEmptyGeoSlotOpen = !this.existingPromoVariationEmptyGeoPaths.has(item.path);
+        return hasUnusedGeo || hasEmptyGeoSlotOpen;
     }
 
     #closeConfirmDialog() {
         this.confirmDialogConfig = null;
     }
 
+    get #promoVariationConfirmButton() {
+        const dialogWrapper = this.shadowRoot?.querySelector('sp-dialog-wrapper.promo-variation-geos-dialog');
+        return dialogWrapper?.shadowRoot?.querySelector('sp-button[variant="accent"][slot="button"]') ?? null;
+    }
+
+    async #syncPromoVariationConfirmButtonDisabled() {
+        if (!this.promoVariationGeosDialogItem) return;
+        const dialogWrapper = this.shadowRoot?.querySelector('sp-dialog-wrapper.promo-variation-geos-dialog');
+        await dialogWrapper?.updateComplete;
+        const confirmButton = this.#promoVariationConfirmButton;
+        if (!confirmButton) return;
+        confirmButton.disabled = !this.promoVariationSelectedGeos.length && this.fragmentHasEmptyGeosVariation;
+    }
+
     #closePromoVariationGeosDialog() {
         this.promoVariationGeosDialogItem = null;
         this.promoVariationSelectedGeos = [];
         this.promoVariationDisabledGeos = [];
+        this.fragmentHasEmptyGeosVariation = false;
     }
 
     #handlePromoVariationGeosChange(e) {
@@ -835,11 +841,13 @@ class MasPromotionsItemsTable extends LitElement {
 
         this.promoVariationSelectedGeos = [];
         this.promoVariationDisabledGeos = [];
+        this.fragmentHasEmptyGeosVariation = false;
         this.createPromoVariationLoading = true;
 
         try {
             const existingVariations = await probePromoVariationsForFragment(this.repository.aem, item.path, promoTag);
             this.promoVariationDisabledGeos = getUsedGeoTags(existingVariations);
+            this.fragmentHasEmptyGeosVariation = existingVariations.some((variation) => !variation.pznTags?.length);
             this.promoVariationGeosDialogItem = item;
         } catch {
             showToast(PROMO_VARIATION_LOOKUP_FAILED_MESSAGE, 'negative');
@@ -867,10 +875,15 @@ class MasPromotionsItemsTable extends LitElement {
         const item = this.promoVariationGeosDialogItem;
         const promoTag = this.#promotionTagId;
         const geoTags = this.promoVariationSelectedGeos;
+        const hasEmptyGeosVariation = this.fragmentHasEmptyGeosVariation;
         this.#closePromoVariationGeosDialog();
         if (!promoTag || !item?.id || !this.repository) return;
-        if (!geoTags.length) {
-            showToast('Select at least one geo to create the promo variation.', 'negative');
+
+        if (!geoTags.length && hasEmptyGeosVariation) {
+            showToast(
+                'A variation with no geos already exists for this project. Select one or more geos to create another variation.',
+                'negative',
+            );
             return;
         }
 
@@ -890,6 +903,9 @@ class MasPromotionsItemsTable extends LitElement {
                 ...previousGeos,
                 ...geoTags,
             ]);
+            if (!geoTags.length) {
+                this.existingPromoVariationEmptyGeoPaths = new Set([...this.existingPromoVariationEmptyGeoPaths, item.path]);
+            }
             await this.#navigateToFragmentEditorFromProject(created.id, created.path);
         } catch (err) {
             showToast(err.message || 'Failed to create promo variation', 'negative');
@@ -1055,6 +1071,7 @@ class MasPromotionsItemsTable extends LitElement {
         if (!this.promoVariationGeosDialogItem) return nothing;
         return html`
             <sp-dialog-wrapper
+                class="promo-variation-geos-dialog"
                 open
                 underlay
                 mode="modal"
@@ -1069,6 +1086,7 @@ class MasPromotionsItemsTable extends LitElement {
                 <mas-promo-variation-geos
                     .geos=${this.#geoValues}
                     .disabledGeos=${this.promoVariationDisabledGeos}
+                    .hasEmptyGeosVariation=${this.fragmentHasEmptyGeosVariation}
                     .value=${this.promoVariationSelectedGeos}
                     @change=${(e) => this.#handlePromoVariationGeosChange(e)}
                 ></mas-promo-variation-geos>
@@ -1078,7 +1096,6 @@ class MasPromotionsItemsTable extends LitElement {
 
     #renderActionsCell(item) {
         const showCreatePromo = this.type === TABLE_TYPE.CARDS && this.#canCreatePromoVariation(item);
-        const showViewPromo = this.type === TABLE_TYPE.CARDS && this.#hasPromoVariationForItem(item);
         return html`<sp-table-cell class="actions-cell">
             <sp-action-menu placement="bottom-end" quiet @click=${(e) => e.stopPropagation()}>
                 <sp-icon-more slot="icon"></sp-icon-more>
@@ -1089,12 +1106,6 @@ class MasPromotionsItemsTable extends LitElement {
                       >
                           <sp-icon-copy slot="icon"></sp-icon-copy>
                           Create promo variation
-                      </sp-menu-item>`
-                    : nothing}
-                ${showViewPromo
-                    ? html`<sp-menu-item @click=${(e) => this.#viewPromoVariation(e, item)}>
-                          <sp-icon-open-in slot="icon"></sp-icon-open-in>
-                          View promo variation
                       </sp-menu-item>`
                     : nothing}
                 ${this.type === TABLE_TYPE.OFFERS

--- a/studio/test/promotions/mas-promo-variation-geos.test.js
+++ b/studio/test/promotions/mas-promo-variation-geos.test.js
@@ -154,4 +154,47 @@ describe('MasPromoVariationGeos', () => {
             expect(el.selectAllIndeterminate).to.be.false;
         });
     });
+
+    describe('inherit hint', () => {
+        it('shows the informational hint when nothing is selected and there is no geo-less sibling', async () => {
+            const el = await fixture(html`<mas-promo-variation-geos .geos=${geos}></mas-promo-variation-geos>`);
+            expect(el.showInheritHint).to.be.true;
+            const hint = el.shadowRoot.querySelector('.inherit-hint');
+            expect(hint).to.exist;
+            expect(hint.classList.contains('blocked')).to.be.false;
+            expect(hint.textContent).to.include('all geos');
+        });
+
+        it('shows the blocked hint when nothing is selected and a geo-less sibling already exists', async () => {
+            const el = await fixture(
+                html`<mas-promo-variation-geos .geos=${geos} .hasEmptyGeosVariation=${true}></mas-promo-variation-geos>`,
+            );
+            expect(el.showInheritHint).to.be.true;
+            const hint = el.shadowRoot.querySelector('.inherit-hint');
+            expect(hint).to.exist;
+            expect(hint.classList.contains('blocked')).to.be.true;
+            expect(hint.textContent).to.include('already exists');
+        });
+
+        it('hides the hint once any geo is checked', async () => {
+            const el = await fixture(
+                html`<mas-promo-variation-geos .geos=${geos} .value=${['mas:pzn/country/ar']}></mas-promo-variation-geos>`,
+            );
+            expect(el.showInheritHint).to.be.false;
+            expect(el.shadowRoot.querySelector('.inherit-hint')).to.not.exist;
+        });
+
+        it('shows the hint even when every geo is already disabled (no selectable geos) — a geo-less variation is still valid', async () => {
+            const el = await fixture(
+                html`<mas-promo-variation-geos .geos=${geos} .disabledGeos=${geos}></mas-promo-variation-geos>`,
+            );
+            expect(el.showInheritHint).to.be.true;
+            expect(el.shadowRoot.querySelector('.inherit-hint')).to.exist;
+        });
+
+        it('hides the hint in compact mode', async () => {
+            const el = await fixture(html`<mas-promo-variation-geos .geos=${geos} compact></mas-promo-variation-geos>`);
+            expect(el.shadowRoot.querySelector('.inherit-hint')).to.not.exist;
+        });
+    });
 });

--- a/studio/test/promotions/mas-promotions-items-table.test.js
+++ b/studio/test/promotions/mas-promotions-items-table.test.js
@@ -721,239 +721,6 @@ describe('MasPromotionsItemsTable', () => {
 
         const menuItems = Array.from(el.shadowRoot.querySelectorAll('sp-menu-item'));
         expect(menuItems.some((item) => item.textContent.trim().includes('Create promo variation'))).to.be.false;
-        expect(menuItems.some((item) => item.textContent.trim().includes('View promo variation'))).to.be.true;
-        el.remove();
-        Store.promotions.inEdit.set(null);
-        Store.promotions.selectedCards.set([]);
-    });
-
-    it('opens promo variation editor when View promo variation is clicked', async () => {
-        const router = (await import('../../src/router.js')).default;
-        const navStub = sandbox.stub(router, 'navigateToFragmentEditor').resolves();
-        const defaultPath = '/content/dam/mas/sandbox/en_US/my-card';
-        const promoVariationPath = '/content/dam/mas/sandbox/en_US/promotions/black-friday/my-card';
-        const promotion = new Fragment({
-            path: '/content/dam/mas/promotions/black-friday',
-            fields: [{ name: 'tags', values: ['mas:promotion/black-friday'], multiple: true }],
-        });
-        Store.promotions.inEdit.set(new FragmentStore(promotion));
-        Store.promotions.selectedCards.set([defaultPath]);
-
-        const el = new MasPromotionsItemsTable();
-        el.type = TABLE_TYPE.CARDS;
-        const fragment = {
-            path: defaultPath,
-            id: 'card-promo-id',
-            title: 'Promo Card',
-            studioPath: defaultPath,
-            status: 'DRAFT',
-            model: { path: CARD_MODEL_PATH },
-            fields: [],
-            tags: [],
-        };
-        sandbox.stub(el, 'repository').get(() => ({
-            aem: {
-                getFragmentByPath: sandbox.stub().resolves(fragment),
-                sites: {
-                    cf: {
-                        fragments: {
-                            getByPath: sandbox.stub().withArgs(promoVariationPath).resolves({
-                                id: 'promo-var-id',
-                                path: promoVariationPath,
-                            }),
-                        },
-                    },
-                },
-            },
-        }));
-        document.body.appendChild(el);
-        await el.updateComplete;
-        await new Promise((r) => setTimeout(r, 80));
-        await el.updateComplete;
-
-        const viewItem = Array.from(el.shadowRoot.querySelectorAll('sp-menu-item')).find((item) =>
-            item.textContent.trim().includes('View promo variation'),
-        );
-        viewItem.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
-        await new Promise((r) => setTimeout(r, 10));
-        expect(navStub.calledOnce).to.be.true;
-        expect(navStub.firstCall.args[0]).to.equal('promo-var-id');
-        el.remove();
-        Store.promotions.inEdit.set(null);
-        Store.promotions.selectedCards.set([]);
-    });
-
-    it('sets Store.search.path to promo variation surface on View promo variation click', async () => {
-        const router = (await import('../../src/router.js')).default;
-        sandbox.stub(router, 'navigateToFragmentEditor').resolves();
-        const searchSetSpy = sandbox.stub(Store.search, 'set');
-        const defaultPath = '/content/dam/mas/nala/en_US/my-card';
-        const promoVariationPath = '/content/dam/mas/nala/en_US/promotions/summer-sale/my-card';
-        const promotion = new Fragment({
-            path: '/content/dam/mas/promotions/summer-sale',
-            fields: [{ name: 'tags', values: ['mas:promotion/summer-sale'], multiple: true }],
-        });
-        Store.promotions.inEdit.set(new FragmentStore(promotion));
-
-        const el = await fixture(html`<mas-promotions-items-table .type=${TABLE_TYPE.CARDS}></mas-promotions-items-table>`);
-        el.existingPromoVariationDefaultPaths = new Set([defaultPath]);
-        el.viewOnlyFragments = [
-            {
-                path: defaultPath,
-                id: 'nala-card-id',
-                title: 'Nala Card',
-                studioPath: defaultPath,
-                status: 'PUBLISHED',
-                model: { path: CARD_MODEL_PATH },
-                fields: [],
-                tags: [],
-            },
-        ];
-        sandbox.stub(el, 'repository').get(() => ({
-            aem: {
-                sites: {
-                    cf: {
-                        fragments: {
-                            getByPath: sandbox.stub().withArgs(promoVariationPath).resolves({
-                                id: 'promo-var-nala-id',
-                                path: promoVariationPath,
-                            }),
-                        },
-                    },
-                },
-            },
-        }));
-        await el.updateComplete;
-
-        const viewItem = Array.from(el.shadowRoot.querySelectorAll('sp-menu-item')).find((item) =>
-            item.textContent.trim().includes('View promo variation'),
-        );
-        viewItem.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
-        await new Promise((r) => setTimeout(r, 10));
-        const pathCall = searchSetSpy.getCalls().find((call) => {
-            const result = call.args[0]({ path: 'sandbox' });
-            return result?.path === 'nala';
-        });
-        expect(pathCall, 'Store.search.set should be called with path=nala').to.not.be.undefined;
-        Store.promotions.inEdit.set(null);
-    });
-
-    it('shows a missing-variation message when View promo variation is clicked but variation was removed', async () => {
-        const toastStub = sandbox.stub(Events.toast, 'emit');
-        const defaultPath = '/content/dam/mas/sandbox/en_US/my-card';
-        const promoVariationPath = '/content/dam/mas/sandbox/en_US/promotions/black-friday/my-card';
-        const promotion = new Fragment({
-            path: '/content/dam/mas/promotions/black-friday',
-            fields: [{ name: 'tags', values: ['mas:promotion/black-friday'], multiple: true }],
-        });
-        Store.promotions.inEdit.set(new FragmentStore(promotion));
-        Store.promotions.selectedCards.set([defaultPath]);
-
-        const el = new MasPromotionsItemsTable();
-        el.type = TABLE_TYPE.CARDS;
-        const fragment = {
-            path: defaultPath,
-            id: 'card-promo-id',
-            title: 'Promo Card',
-            studioPath: defaultPath,
-            status: 'DRAFT',
-            model: { path: CARD_MODEL_PATH },
-            fields: [],
-            tags: [],
-        };
-        let promoPathLookupCount = 0;
-        sandbox.stub(el, 'repository').get(() => ({
-            aem: {
-                getFragmentByPath: sandbox.stub().resolves(fragment),
-                sites: {
-                    cf: {
-                        fragments: {
-                            getByPath: sandbox.stub().callsFake((path) => {
-                                if (path !== promoVariationPath) return Promise.resolve(null);
-                                promoPathLookupCount += 1;
-                                if (promoPathLookupCount === 1) {
-                                    return Promise.resolve({ id: 'promo-var-id', path: promoVariationPath });
-                                }
-                                return Promise.resolve(null);
-                            }),
-                        },
-                    },
-                },
-            },
-        }));
-        document.body.appendChild(el);
-        await el.updateComplete;
-        await new Promise((r) => setTimeout(r, 80));
-        await el.updateComplete;
-
-        const viewItem = Array.from(el.shadowRoot.querySelectorAll('sp-menu-item')).find((item) =>
-            item.textContent.trim().includes('View promo variation'),
-        );
-        viewItem.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
-        await new Promise((r) => setTimeout(r, 10));
-        expect(toastStub.calledOnce).to.be.true;
-        expect(toastStub.firstCall.args[0].content).to.include('could not be found');
-        el.remove();
-        Store.promotions.inEdit.set(null);
-        Store.promotions.selectedCards.set([]);
-    });
-
-    it('shows lookup-failed message on View when getByPath fails with a non-404 error', async () => {
-        const toastStub = sandbox.stub(Events.toast, 'emit');
-        const defaultPath = '/content/dam/mas/sandbox/en_US/my-card';
-        const promoVariationPath = '/content/dam/mas/sandbox/en_US/promotions/black-friday/my-card';
-        const promotion = new Fragment({
-            path: '/content/dam/mas/promotions/black-friday',
-            fields: [{ name: 'tags', values: ['mas:promotion/black-friday'], multiple: true }],
-        });
-        Store.promotions.inEdit.set(new FragmentStore(promotion));
-        Store.promotions.selectedCards.set([defaultPath]);
-
-        const el = new MasPromotionsItemsTable();
-        el.type = TABLE_TYPE.CARDS;
-        const fragment = {
-            path: defaultPath,
-            id: 'card-promo-id',
-            title: 'Promo Card',
-            studioPath: defaultPath,
-            status: 'DRAFT',
-            model: { path: CARD_MODEL_PATH },
-            fields: [],
-            tags: [],
-        };
-        let promoPathLookupCount = 0;
-        sandbox.stub(el, 'repository').get(() => ({
-            aem: {
-                getFragmentByPath: sandbox.stub().resolves(fragment),
-                sites: {
-                    cf: {
-                        fragments: {
-                            getByPath: sandbox.stub().callsFake((path) => {
-                                if (path !== promoVariationPath) return Promise.resolve(null);
-                                promoPathLookupCount += 1;
-                                if (promoPathLookupCount === 1) {
-                                    return Promise.resolve({ id: 'promo-var-id', path: promoVariationPath });
-                                }
-                                return Promise.reject(new Error('Server error'));
-                            }),
-                        },
-                    },
-                },
-            },
-        }));
-        document.body.appendChild(el);
-        await el.updateComplete;
-        await new Promise((r) => setTimeout(r, 80));
-        await el.updateComplete;
-
-        const viewItem = Array.from(el.shadowRoot.querySelectorAll('sp-menu-item')).find((item) =>
-            item.textContent.trim().includes('View promo variation'),
-        );
-        viewItem.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
-        await new Promise((r) => setTimeout(r, 10));
-        expect(toastStub.calledOnce).to.be.true;
-        expect(toastStub.firstCall.args[0].content).to.include('Could not verify the promo variation');
-        expect(el.existingPromoVariationDefaultPaths.has(defaultPath)).to.be.true;
         el.remove();
         Store.promotions.inEdit.set(null);
         Store.promotions.selectedCards.set([]);
@@ -1350,7 +1117,6 @@ describe('MasPromotionsItemsTable', () => {
 
             const menuItems = Array.from(el.shadowRoot.querySelectorAll('sp-menu-item'));
             expect(menuItems.some((item) => item.textContent.trim().includes('Create promo variation'))).to.be.true;
-            expect(menuItems.some((item) => item.textContent.trim().includes('View promo variation'))).to.be.true;
             el.remove();
             Store.promotions.selectedCards.set([]);
         });
@@ -1373,7 +1139,26 @@ describe('MasPromotionsItemsTable', () => {
             expect(findCreateMenuItem(el)).to.not.be.undefined;
         });
 
-        it('hides Create promo variation when every project geo is already used by existing variations', async () => {
+        it('hides Create promo variation when every project geo and the geo-less slot are already used', async () => {
+            const promotion = new Fragment({
+                path: '/content/dam/mas/promotions/black-friday',
+                fields: [
+                    { name: 'tags', values: [promoTag], multiple: true },
+                    { name: 'geos', values: ['mas:locale/de_AT', 'mas:locale/en_NG'], multiple: true },
+                ],
+            });
+            Store.promotions.inEdit.set(new FragmentStore(promotion));
+
+            const el = await fixture(html`<mas-promotions-items-table .type=${TABLE_TYPE.CARDS}></mas-promotions-items-table>`);
+            el.existingPromoVariationGeosByPath = new Map([[defaultPath, ['mas:locale/de_AT', 'mas:locale/en_NG']]]);
+            el.existingPromoVariationEmptyGeoPaths = new Set([defaultPath]);
+            el.viewOnlyFragments = [cardFragment];
+            await el.updateComplete;
+
+            expect(findCreateMenuItem(el)).to.be.undefined;
+        });
+
+        it('shows Create promo variation for the geo-less slot when every project geo is used but no geo-less variation exists yet', async () => {
             const promotion = new Fragment({
                 path: '/content/dam/mas/promotions/black-friday',
                 fields: [
@@ -1388,7 +1173,7 @@ describe('MasPromotionsItemsTable', () => {
             el.viewOnlyFragments = [cardFragment];
             await el.updateComplete;
 
-            expect(findCreateMenuItem(el)).to.be.undefined;
+            expect(findCreateMenuItem(el)).to.not.be.undefined;
         });
 
         it('shows Create promo variation when the only recorded geos are from a legacy variation (empty pznTags)', async () => {
@@ -1403,14 +1188,149 @@ describe('MasPromotionsItemsTable', () => {
 
             const el = await fixture(html`<mas-promotions-items-table .type=${TABLE_TYPE.CARDS}></mas-promotions-items-table>`);
             el.existingPromoVariationGeosByPath = new Map([[defaultPath, []]]);
+            el.existingPromoVariationEmptyGeoPaths = new Set([defaultPath]);
             el.viewOnlyFragments = [cardFragment];
             await el.updateComplete;
 
             expect(findCreateMenuItem(el)).to.not.be.undefined;
         });
 
-        it('shows a toast and does not create when no geo is selected', async () => {
+        it('creates a geo-less promo variation when nothing is checked and no empty-geo sibling exists', async () => {
+            const router = (await import('../../src/router.js')).default;
+            const navStub = sandbox.stub(router, 'navigateToFragmentEditor').resolves();
             const toastStub = sandbox.stub(Events.toast, 'emit');
+            const promotion = new Fragment({
+                path: '/content/dam/mas/promotions/black-friday',
+                id: 'promo-project-id',
+                fields: [
+                    { name: 'tags', values: [promoTag], multiple: true },
+                    { name: 'geos', values: ['mas:locale/de_AT', 'mas:locale/en_NG'], multiple: true },
+                ],
+            });
+            Store.promotions.inEdit.set(new FragmentStore(promotion));
+
+            const aem = createPromoVariationAem({
+                fragments: {
+                    getByPath: sandbox.stub().callsFake((path) =>
+                        path === promoVariationPath
+                            ? Promise.resolve({
+                                  id: 'existing-var',
+                                  path: promoVariationPath,
+                                  fields: [{ name: 'pznTags', values: ['mas:locale/de_AT'] }],
+                              })
+                            : Promise.resolve(null),
+                    ),
+                },
+            });
+            const el = await fixture(html`<mas-promotions-items-table .type=${TABLE_TYPE.CARDS}></mas-promotions-items-table>`);
+            sandbox.stub(el, 'repository').get(() => ({
+                refreshFragment: sandbox.stub().resolves(),
+                aem,
+            }));
+            el.viewOnlyFragments = [cardFragment];
+            await el.updateComplete;
+
+            await clickCreateAndWaitForDialog(el);
+            expect(el.promoVariationDisabledGeos).to.deep.equal(['mas:locale/de_AT']);
+            expect(el.promoVariationSelectedGeos).to.deep.equal([]);
+            expect(el.fragmentHasEmptyGeosVariation).to.be.false;
+
+            el.shadowRoot.querySelector('sp-dialog-wrapper').dispatchEvent(new CustomEvent('confirm'));
+            await el.updateComplete;
+            await new Promise((r) => setTimeout(r, 10));
+            el.shadowRoot.querySelector('sp-dialog-wrapper').dispatchEvent(new CustomEvent('confirm'));
+            await el.updateComplete;
+            await new Promise((r) => setTimeout(r, 10));
+
+            expect(toastStub.getCalls().some((call) => call.args[0].content?.includes('Select at least one geo'))).to.be.false;
+            expect(aem.createFragmentCopy.calledOnce).to.be.true;
+            const [fragmentForCopy] = aem.createFragmentCopy.firstCall.args;
+            expect(fragmentForCopy.fields.find((field) => field.name === 'pznTags')).to.be.undefined;
+            expect(el.existingPromoVariationGeosByPath.get(defaultPath)).to.deep.equal([]);
+            expect(navStub.calledOnce).to.be.true;
+        });
+
+        it('blocks with a toast when nothing is checked and a geo-less sibling variation already exists', async () => {
+            const toastStub = sandbox.stub(Events.toast, 'emit');
+            setupPromotionInEdit();
+
+            const aem = createPromoVariationAem({
+                fragments: {
+                    getByPath: sandbox.stub().callsFake((path) =>
+                        path === promoVariationPath
+                            ? Promise.resolve({
+                                  id: 'existing-var',
+                                  path: promoVariationPath,
+                                  fields: [{ name: 'title', values: ['Promo Card'] }],
+                              })
+                            : Promise.resolve(null),
+                    ),
+                },
+            });
+            const el = await fixture(html`<mas-promotions-items-table .type=${TABLE_TYPE.CARDS}></mas-promotions-items-table>`);
+            sandbox.stub(el, 'repository').get(() => ({
+                refreshFragment: sandbox.stub().resolves(),
+                aem,
+            }));
+            el.viewOnlyFragments = [cardFragment];
+            await el.updateComplete;
+
+            await clickCreateAndWaitForDialog(el);
+            expect(el.promoVariationDisabledGeos).to.deep.equal([]);
+            expect(el.fragmentHasEmptyGeosVariation).to.be.true;
+
+            el.shadowRoot.querySelector('sp-dialog-wrapper').dispatchEvent(new CustomEvent('confirm'));
+            await new Promise((r) => setTimeout(r, 20));
+            await el.updateComplete;
+
+            expect(aem.createFragmentCopy.called).to.be.false;
+            expect(toastStub.getCalls().some((call) => call.args[0].content?.includes('already exists'))).to.be.true;
+        });
+
+        it('disables Continue until a geo is checked when a geo-less sibling variation already exists', async () => {
+            setupPromotionInEdit();
+
+            const aem = createPromoVariationAem({
+                fragments: {
+                    getByPath: sandbox.stub().callsFake((path) =>
+                        path === promoVariationPath
+                            ? Promise.resolve({
+                                  id: 'existing-var',
+                                  path: promoVariationPath,
+                                  fields: [{ name: 'title', values: ['Promo Card'] }],
+                              })
+                            : Promise.resolve(null),
+                    ),
+                },
+            });
+            const el = await fixture(html`<mas-promotions-items-table .type=${TABLE_TYPE.CARDS}></mas-promotions-items-table>`);
+            sandbox.stub(el, 'repository').get(() => ({
+                refreshFragment: sandbox.stub().resolves(),
+                aem,
+            }));
+            el.viewOnlyFragments = [cardFragment];
+            await el.updateComplete;
+
+            await clickCreateAndWaitForDialog(el);
+            expect(el.fragmentHasEmptyGeosVariation).to.be.true;
+
+            const dialogWrapper = el.shadowRoot.querySelector('sp-dialog-wrapper.promo-variation-geos-dialog');
+            await dialogWrapper.updateComplete;
+            const confirmButton = dialogWrapper.shadowRoot.querySelector('sp-button[variant="accent"][slot="button"]');
+            expect(confirmButton.disabled).to.be.true;
+
+            el.promoVariationSelectedGeos = ['mas:pzn/country/ar'];
+            await el.updateComplete;
+            await dialogWrapper.updateComplete;
+            expect(confirmButton.disabled).to.be.false;
+
+            el.promoVariationSelectedGeos = [];
+            await el.updateComplete;
+            await dialogWrapper.updateComplete;
+            expect(confirmButton.disabled).to.be.true;
+        });
+
+        it('leaves Continue enabled when nothing is checked and there is no geo-less sibling', async () => {
             setupPromotionInEdit();
             const aem = createPromoVariationAem();
             const el = await fixture(html`<mas-promotions-items-table .type=${TABLE_TYPE.CARDS}></mas-promotions-items-table>`);
@@ -1422,12 +1342,12 @@ describe('MasPromotionsItemsTable', () => {
             await el.updateComplete;
 
             await clickCreateAndWaitForDialog(el);
-            el.shadowRoot.querySelector('sp-dialog-wrapper').dispatchEvent(new CustomEvent('confirm'));
-            await new Promise((r) => setTimeout(r, 20));
-            await el.updateComplete;
+            expect(el.fragmentHasEmptyGeosVariation).to.be.false;
 
-            expect(aem.createFragmentCopy.called).to.be.false;
-            expect(toastStub.getCalls().some((call) => call.args[0].content.includes('Select at least one geo'))).to.be.true;
+            const dialogWrapper = el.shadowRoot.querySelector('sp-dialog-wrapper.promo-variation-geos-dialog');
+            await dialogWrapper.updateComplete;
+            const confirmButton = dialogWrapper.shadowRoot.querySelector('sp-button[variant="accent"][slot="button"]');
+            expect(confirmButton.disabled).to.be.false;
         });
 
         it('shows error toast when createPromoVariation fails', async () => {

--- a/studio/test/promotions/promotion-variations.test.js
+++ b/studio/test/promotions/promotion-variations.test.js
@@ -292,6 +292,48 @@ describe('promotion-variations', () => {
             expect(result).to.deep.equal(createdFragment);
             expect(aem.saveTags.firstCall.args[0].newTags).to.deep.equal([promoTag]);
         });
+
+        it('does not block a later explicit-geo variation when a geo-less fallback sibling already exists', async () => {
+            const createdDraft = { id: 'fallback-var' };
+            const createdFragment = { id: 'fallback-var', path: targetPath };
+            const aemForFallback = createAemMock({
+                fragments: {
+                    getById: sandbox.stub().resolves(parentFragment),
+                    getByPath: sandbox.stub().resolves(null),
+                    pollCreatedFragment: sandbox.stub().resolves(createdFragment),
+                },
+                createFragmentCopy: sandbox.stub().resolves(createdDraft),
+            });
+
+            // Simulates Task 1's confirm handler: confirming with zero geos checked
+            // passes [] straight through, so createPromoVariation omits pznTags entirely.
+            await createPromoVariation(aemForFallback, parentFragment.id, promoTag, []);
+
+            const [fragmentForCopy] = aemForFallback.createFragmentCopy.firstCall.args;
+            expect(fragmentForCopy.fields.find((field) => field.name === 'pznTags')).to.be.undefined;
+
+            const existingVariations = [{ pznTags: [] }];
+            expect(findOverlappingGeoTags(existingVariations, ['mas:pzn/country/ar'])).to.deep.equal([]);
+
+            const secondVariationPath = '/content/dam/mas/sandbox/en_US/promotions/black-friday/my-card-2';
+            const getByPathForSecond = sandbox.stub();
+            getByPathForSecond.withArgs(targetPath).resolves({
+                id: 'fallback-var',
+                path: targetPath,
+                fields: [],
+            });
+            getByPathForSecond.resolves(null);
+            const aemForSecond = createAemMock({
+                fragments: {
+                    getById: sandbox.stub().resolves(parentFragment),
+                    getByPath: getByPathForSecond,
+                    pollCreatedFragment: sandbox.stub().resolves({ id: 'second-var', path: secondVariationPath }),
+                },
+            });
+
+            const result = await createPromoVariation(aemForSecond, parentFragment.id, promoTag, ['mas:pzn/country/ar']);
+            expect(result).to.deep.equal({ id: 'second-var', path: secondVariationPath });
+        });
     });
 
     describe('probePromoVariationsForFragment', () => {


### PR DESCRIPTION
The promotion project may have only one promotion variation with no geos specified - this variation automatically applies to all promotion project geos (for those added later as well).
When resolving which promotion variation to show, we first check if the promotion project has the variation for the specific geo. If not, we use the content from the promotion variation with no geos.

Resolves https://jira.corp.adobe.com/browse/MWPW-201030
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [x] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [x] C4. PR description contains working Test Page link where the feature can be tested
- [x] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [x] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing

## 🧪 Nala E2E Tests

Nala tests run automatically when you **open this PR**.

### To run Nala tests again:

1. Add the `run nala` label to this PR (in the right sidebar)
2. Tests will run automatically on the current commit
3. Any future commits will also trigger tests **as long as the label remains**

### To stop automatic Nala tests:

- Remove the `run nala` label

> **Note**: Tests only run on commits if the `run nala` label is present. Add the label whenever you need tests to run on new changes.

## Test URLs:

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-201030--mas--adobecom.aem.live/
