### PR TITLE
MWPW-202019: Release mas-js v0.8.1 and fix release-version drift

### DIFF
--- a/.claude/commands/release-mas-js.md
+++ b/.claude/commands/release-mas-js.md
@@ -8,11 +8,20 @@ Release the `@adobecom/mas` npm package and create a GitHub release at `adobecom
 
 ## Steps
 
-### 1. Determine the version
+### 1. Determine the current version
 
-Read `web-components/package.json` to show the current version.
+The **published GitHub release** is the source of truth for the current version — not `package.json`, which can drift if a prior release's bump commit (step 10) never landed.
 
-If `$ARGUMENTS` is empty or not a valid semver, use the AskUserQuestion tool to ask the user for the target version.
+```bash
+gh release list --repo adobecom/mas --limit 10 --json tagName,publishedAt,name
+```
+
+Take the highest `mas-js-v*` tag as the current version. Then read `web-components/package.json` and compare:
+
+- If `package.json` is **behind** the latest release tag, it drifted (a previous bump commit was never committed/pushed). Warn the user, and treat the release tag — not `package.json` — as the baseline for choosing the next version.
+- If they match, proceed normally.
+
+If `$ARGUMENTS` is empty or not a valid semver, use the AskUserQuestion tool to ask the user for the target version, showing both the latest release tag and the `package.json` value so the choice is made against the true baseline.
 
 ### 2. Bump the version in package.json
 
@@ -26,13 +35,9 @@ cd web-components && npm install
 
 This updates `package-lock.json` with the new version.
 
-### 4. Find the previous release
+### 4. Find the previous release date
 
-```bash
-gh release list --repo adobecom/mas --limit 10 --json tagName,publishedAt,name
-```
-
-Identify the most recent `mas-js-v*` release tag and its `publishedAt` date.
+Reuse the release list from step 1. Take the most recent `mas-js-v*` tag's `publishedAt` date as `LAST_RELEASE_DATE` for the PR query below.
 
 ### 5. Collect merged PRs since the last release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40395,7 +40395,7 @@
         },
         "web-components": {
             "name": "@adobecom/mas",
-            "version": "0.7.3",
+            "version": "0.8.0",
             "devDependencies": {
                 "@dexter/tacocat-core": "file:./internal/tacocat-core-1.13.1.tgz",
                 "@esm-bundle/chai": "4.3.4-fix.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40395,7 +40395,7 @@
         },
         "web-components": {
             "name": "@adobecom/mas",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "devDependencies": {
                 "@dexter/tacocat-core": "file:./internal/tacocat-core-1.13.1.tgz",
                 "@esm-bundle/chai": "4.3.4-fix.0",

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobecom/mas",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "type": "module",
     "main": "dist/mas.js",
     "private": true,

--- a/web-components/package.json
+++ b/web-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobecom/mas",
-    "version": "0.7.3",
+    "version": "0.8.0",
     "type": "module",
     "main": "dist/mas.js",
     "private": true,


### PR DESCRIPTION
Cuts the **mas-js v0.8.1** release and reconciles the recorded version with the release history.

- **Version reconcile:** `package.json` sat at `0.7.3` while the latest published release was `mas-js-v0.8.0` — the 0.8.0 bump commit never landed, leaving the repo a release behind. Realigned to `0.8.0`, then bumped to `0.8.1` for this release.
- **Skill fix:** `release-mas-js` now keys the current-version check off the highest published `mas-js-v*` tag instead of `package.json`, so a missed bump commit can no longer silently rewind the baseline (root cause of the drift above).

The GitHub release `mas-js-v0.8.1` will be cut from the merge commit after this PR lands.

Resolves https://jira.corp.adobe.com/browse/MWPW-202019

## Test URLs

- Before: https://main--mas--adobecom.aem.live/
- After: https://mwpw-202019--mas--adobecom.aem.live/

## Checklist

- [x] No source/behavior change — version metadata (`package.json` + `package-lock.json`) and release-tooling doc only
- [x] `package.json` reconciled to published release history; bumped to `0.8.1`
- [x] Release cut from merge commit post-merge (avoids version drift)
