### PR TITLE
MWPW-202062: no mapping no promo

### DIFF
--- a/io/www/src/fragment/transformers/customize.js
+++ b/io/www/src/fragment/transformers/customize.js
@@ -250,8 +250,8 @@ function findPromoMapsForFragment(root, customizeContext) {
 
 /**
  * Selects a single promo project for a fragment.
- * explicit mapping (osi replace or promo code) wins over wild card promo only
- * wildcard promo wins over no promo and no mapping
+ * explicit mapping (osi replace or promo code) wins over wild card promo
+ * a project with neither an explicit mapping nor a wildcard does not qualify.
  *
  * @returns the selected `{ project, promoMap, substituteMap, fragmentPaths }` entry, or null
  *          when no promo project targets the fragment.
@@ -264,7 +264,8 @@ function selectPromoProjectForFragment(root, customizeContext) {
     const hasExplicitMapping = ({ promoMap, substituteMap }) =>
         osis.some((osi) => promoMap[osi] !== undefined || substituteMap?.[osi] !== undefined);
     const hasWildcardPromo = ({ promoMap }) => Boolean(promoMap['*']);
-    const selected = promoEntries.find(hasExplicitMapping) ?? promoEntries.find(hasWildcardPromo) ?? promoEntries[0];
+    const selected = promoEntries.find(hasExplicitMapping) ?? promoEntries.find(hasWildcardPromo) ?? null;
+    if (!selected) return null;
     logDebug(
         () =>
             `Selected promo project ${selected.project.id} for fragment ${root.id} out of ${promoEntries.length} targeting project(s)`,

--- a/io/www/test/fragment/customize.test.js
+++ b/io/www/test/fragment/customize.test.js
@@ -1592,6 +1592,7 @@ describe('customize promo variation', function () {
         const result = await processWithPromos(
             { ...FAKE_CONTEXT, fragmentPath: 'my-card', parsedLocale: 'en_US', body: rootFragment },
             ACTIVE_PROJECT,
+            { '*': 'WILDCARD-PROMO' },
         );
 
         expect(result.status).to.equal(200);
@@ -1651,6 +1652,7 @@ describe('customize promo variation', function () {
         const result = await processWithPromos(
             { ...FAKE_CONTEXT, fragmentPath: 'my-card', parsedLocale: 'en_US', body: rootFragment },
             project,
+            { '*': 'WILDCARD-PROMO' },
         );
 
         expect(result.status).to.equal(200);
@@ -1753,6 +1755,7 @@ describe('customize promo variation', function () {
         const result = await processWithPromos(
             { ...FAKE_CONTEXT, fragmentPath: 'my-card', parsedLocale: 'en_US', body: rootFragment },
             project,
+            { '*': 'WILDCARD-PROMO' },
         );
 
         expect(result.status).to.equal(200);
@@ -1795,6 +1798,7 @@ describe('customize promo variation', function () {
                 country: 'GR',
             },
             project,
+            { '*': 'WILDCARD-PROMO' },
         );
 
         expect(result.status).to.equal(200);
@@ -1836,6 +1840,7 @@ describe('customize promo variation', function () {
                 country: 'FR',
             },
             project,
+            { '*': 'WILDCARD-PROMO' },
         );
 
         expect(result.status).to.equal(200);
@@ -1877,6 +1882,7 @@ describe('customize promo variation', function () {
                 country: 'GR',
             },
             project,
+            { '*': 'WILDCARD-PROMO' },
         );
 
         expect(result.status).to.equal(200);
@@ -2470,9 +2476,9 @@ describe('customize with multiple active promotion projects', function () {
         expect(result.body.promoProject).to.equal('proj-sub');
     });
 
-    it('selects the first targeting project for a fragment with no osi', async function () {
-        // A fragment without an osi can have no explicit mapping, so the first targeting project is
-        // selected and its variation applies.
+    it('selects no promo project for a fragment with no osi and no explicit or wildcard mapping', async function () {
+        // A fragment without an osi can never have an explicit mapping; with no wildcard either,
+        // the targeting project does not qualify and no promo is applied.
         const projectVariationOnly = {
             id: 'proj-var',
             path: '/content/dam/mas/promotions/proj-var',
@@ -2496,8 +2502,8 @@ describe('customize with multiple active promotion projects', function () {
             { project: projectVariationOnly, promoMap: {}, fragmentPaths: new Set(['card-x']) },
         ]);
         expect(result.status).to.equal(200);
-        expect(result.body.variationId).to.equal('var-x');
-        expect(result.body.promoProject).to.equal('proj-var');
+        expect(result.body.variationId).to.equal(undefined);
+        expect(result.body.promoProject).to.equal(undefined);
     });
 
     it('selects a wildcard-promo project over a mapping-less project when neither has an explicit entry', async function () {
@@ -2543,7 +2549,7 @@ describe('customize with multiple active promotion projects', function () {
         expect(result.body.promoVariationProject).to.equal(undefined);
     });
 
-    it('stamps promoVariationProject from the variation project when no promoCode is applied', async function () {
+    it('applies no promo project when the only candidate has neither an explicit mapping nor a wildcard', async function () {
         const projectVarOnly = {
             id: 'proj-var-only',
             path: '/content/dam/mas/promotions/proj-var-only',
@@ -2567,12 +2573,11 @@ describe('customize with multiple active promotion projects', function () {
             { project: projectVarOnly, promoMap: {}, fragmentPaths: new Set(['card-y']) },
         ]);
         expect(result.status).to.equal(200);
-        expect(result.body.variationId).to.equal('var-y');
+        expect(result.body.variationId).to.equal(undefined);
         expect(result.body.fields.promoCode).to.be.undefined;
-        // The selected project is stamped as promoProject even without a promoCode, so
-        // data-promotion-project is set for any targeted card.
-        expect(result.body.promoProject).to.equal('proj-var-only');
-        expect(result.body.promoVariationProject).to.equal('proj-var-only');
+        // No explicit mapping for OSI-Y and no wildcard, so the project does not qualify at all.
+        expect(result.body.promoProject).to.equal(undefined);
+        expect(result.body.promoVariationProject).to.equal(undefined);
     });
 
     it('seasonal promo are over evergreen promo targeting the same fragment', async function () {

--- a/io/www/test/fragment/pipeline-e2e.test.js
+++ b/io/www/test/fragment/pipeline-e2e.test.js
@@ -432,7 +432,7 @@ describe('pipeline end to end', () => {
         expect(result.body.fields.promoCode).to.equal('BF2025');
     });
 
-    it('substitutes and promo-matches an OSI injected into a placeholder value (replace runs before wcs)', async () => {
+    it('does not promo-match an OSI injected into a placeholder value when the fragment osi has no explicit or wildcard mapping', async () => {
         setupFragmentMocks(fetchStub, { id: 'some-en-us-fragment', path: 'someFragment' });
 
         // Fragment prices field is a placeholder; its own osi (OWN-OSI) is NOT in the promo.
@@ -476,9 +476,11 @@ describe('pipeline end to end', () => {
                 }),
             );
 
-        // Active promo targeting this fragment: substitutes INJECTED-OSI -> SUB-INJECTED and promotes
-        // the substituted osi. No project-level (wildcard) promoCode, so the code can only land if the
-        // injected osi participates in matching.
+        // Promo project targets this fragment's path, and does define a substitution/promo code —
+        // but only for INJECTED-OSI/SUB-INJECTED, neither of which is the fragment's own osi
+        // (OWN-OSI) at customize time, and there is no wildcard promoCode either. So the project
+        // does not qualify for this fragment: no scope is recorded, and the OSI injected later by
+        // the replace transformer is never seen by wcs.
         const project = makeProject({
             id: 'proj-bts',
             path: '/content/dam/mas/promotions/bts',
@@ -500,24 +502,20 @@ describe('pipeline end to end', () => {
         });
         fetchStub.withArgs(hydrateUrl('proj-bts')).returns(createResponse(200, hydrated));
 
-        // WCS resolves the substituted, promoted offer.
-        fetchStub
-            .withArgs(
-                sinon.match((url) => url.includes('offer_selector_ids=SUB-INJECTED') && url.includes('promotion_code=BTS26')),
-            )
-            .returns(createResponse(200, { resolvedOffers: [{ id: 'bts-offer' }] }));
-
+        // WCS resolves the plain, unpromoted injected offer (falls through to the default
+        // resolvedOffers:[] stub registered by setupFragmentMocks for any web_commerce_artifact call).
         const state = new MockState();
         const result = await getFragment({ id: 'some-en-us-fragment', state, locale: 'fr_FR' });
 
         expect(result.statusCode).to.equal(200);
-        // The placeholder-injected OSI is substituted in the baked markup...
-        expect(result.body.fields.prices.value).to.include('data-wcs-osi="SUB-INJECTED"');
-        expect(result.body.fields.prices.value).to.not.include('INJECTED-OSI');
-        // ...and it drove the promo code match even though the fragment's own osi did not.
-        expect(result.body.fields.promoCode).to.equal('BTS26');
-        // ...and the substituted, promoted offer is in the WCS cache.
+        // The placeholder-injected OSI is left untouched — no substitution happened...
+        expect(result.body.fields.prices.value).to.include('data-wcs-osi="INJECTED-OSI"');
+        expect(result.body.fields.prices.value).to.not.include('SUB-INJECTED');
+        // ...no promo code was applied...
+        expect(result.body.fields.promoCode).to.be.undefined;
+        // ...and only the plain, unpromoted offer is in the WCS cache.
         const cacheKeys = Object.keys(result.body.wcs.prod);
-        expect(cacheKeys.some((key) => key.startsWith('SUB-INJECTED-') && key.endsWith('-bts26'))).to.be.true;
+        expect(cacheKeys.some((key) => key.startsWith('SUB-INJECTED-'))).to.be.false;
+        expect(cacheKeys.some((key) => key.startsWith('INJECTED-OSI-') && !key.endsWith('bts26'))).to.be.true;
     });
 });


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-202062

Retain fallback for seasonal promos, but not for evergreen ones.

- [x] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [ ] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing


## Test URLs:

- Before: https://main--da-cc--adobecom.aem.page/products/indesign?instant=2026-08-18T14:00:00.000Z&country=US
- After: https://main--da-cc--adobecom.aem.page/products/indesign?instant=2026-08-18T14:00:00.000Z&country=US&maslibs=MWPW-202062
