### PR TITLE
MWPW-202583: fallback to seasonal promos

### DIFF
--- a/io/www/src/fragment/transformers/customize.js
+++ b/io/www/src/fragment/transformers/customize.js
@@ -249,9 +249,11 @@ function findPromoMapsForFragment(root, customizeContext) {
 }
 
 /**
- * Selects a single promo project for a fragment.
- * explicit mapping (osi replace or promo code) wins over wild card promo
- * a project with neither an explicit mapping nor a wildcard does not qualify.
+ * Selects a single promo project for a fragment. Priority order is:
+ * promo project with an explicit mapping (osi replace or promo code) for a given geo & fragment.offer
+ * promo project with a wildcard promo code
+ * seasonal promo project, if no seasonal - returns null
+ * there should be no fallback to mapping-less evergreen promo project
  *
  * @returns the selected `{ project, promoMap, substituteMap, fragmentPaths }` entry, or null
  *          when no promo project targets the fragment.
@@ -264,7 +266,12 @@ function selectPromoProjectForFragment(root, customizeContext) {
     const hasExplicitMapping = ({ promoMap, substituteMap }) =>
         osis.some((osi) => promoMap[osi] !== undefined || substituteMap?.[osi] !== undefined);
     const hasWildcardPromo = ({ promoMap }) => Boolean(promoMap['*']);
-    const selected = promoEntries.find(hasExplicitMapping) ?? promoEntries.find(hasWildcardPromo) ?? null;
+    const isSeasonal = ({ project }) => Boolean(project.endDate);
+    const selected =
+        promoEntries.find(hasExplicitMapping) ??
+        promoEntries.find(hasWildcardPromo) ??
+        promoEntries.find(isSeasonal) ??
+        null;
     if (!selected) return null;
     logDebug(
         () =>

--- a/io/www/src/fragment/transformers/customize.js
+++ b/io/www/src/fragment/transformers/customize.js
@@ -268,10 +268,7 @@ function selectPromoProjectForFragment(root, customizeContext) {
     const hasWildcardPromo = ({ promoMap }) => Boolean(promoMap['*']);
     const isSeasonal = ({ project }) => Boolean(project.endDate);
     const selected =
-        promoEntries.find(hasExplicitMapping) ??
-        promoEntries.find(hasWildcardPromo) ??
-        promoEntries.find(isSeasonal) ??
-        null;
+        promoEntries.find(hasExplicitMapping) ?? promoEntries.find(hasWildcardPromo) ?? promoEntries.find(isSeasonal) ?? null;
     if (!selected) return null;
     logDebug(
         () =>

--- a/io/www/src/fragment/transformers/promotions.js
+++ b/io/www/src/fragment/transformers/promotions.js
@@ -353,6 +353,8 @@ async function hydrateProject(project, { baseUrl, surface, defaultLocale, resolv
         id: project.id,
         path: project.path,
         title,
+        startDate: project.startDate,
+        endDate: project.endDate,
         promoCode,
         fragmentPaths,
         offerOverrides,

--- a/io/www/test/fragment/customize.test.js
+++ b/io/www/test/fragment/customize.test.js
@@ -2580,6 +2580,37 @@ describe('customize with multiple active promotion projects', function () {
         expect(result.body.promoVariationProject).to.equal(undefined);
     });
 
+    it('falls back to a seasonal (time-boxed) project with no explicit mapping or wildcard', async function () {
+        // MWPW-202583: falllback to a seasonal campaign without mapping
+        const seasonalProject = {
+            id: 'proj-seasonal',
+            path: '/content/dam/mas/promotions/seasonal',
+            endDate: '2026-09-01T00:00:00.000Z',
+            defaultVariations: {
+                'card-x': {
+                    id: 'var-seasonal',
+                    path: '/content/dam/mas/sandbox/en_US/promotions/seasonal/card-x',
+                    fields: { title: 'Seasonal variation' },
+                },
+            },
+            regionVariations: {},
+        };
+        const rootFragment = {
+            id: 'card-x',
+            path: '/content/dam/mas/sandbox/en_US/card-x',
+            fields: { osi: 'OSI-X', title: 'Original X' },
+            references: {},
+            referencesTree: [],
+        };
+        const result = await processWithPromoProjects({ ...FAKE_CONTEXT, fragmentPath: 'card-x', body: rootFragment }, [
+            { project: seasonalProject, promoMap: {}, fragmentPaths: new Set(['card-x']) },
+        ]);
+        expect(result.status).to.equal(200);
+        expect(result.body.variationId).to.equal('var-seasonal');
+        expect(result.body.promoProject).to.equal('proj-seasonal');
+        expect(result.body.fields.promoCode).to.be.undefined;
+    });
+
     it('seasonal promo are over evergreen promo targeting the same fragment', async function () {
         const seasonalProject = {
             id: 'proj-seasonal',

--- a/io/www/test/fragment/promotions.test.js
+++ b/io/www/test/fragment/promotions.test.js
@@ -162,7 +162,7 @@ describe('promotions', () => {
             expect(result.activeProjects[0].promoCode).to.equal('SAVE20');
         });
 
-        it('carries the project title through hydration', async () => {
+        it('carries the project title, startDate and endDate through hydration', async () => {
             const project = makeProject({ id: 'proj-1', surfaces: ['acom'], geos: ['/content/cq:tags/mas/locale/en_US'] });
             const hydrated = makeHydratedProject({ title: 'Summer Sale 2026' });
             fetchStub.withArgs(FOLDER_URL).returns(createResponse(200, { items: [project] }));
@@ -170,6 +170,8 @@ describe('promotions', () => {
 
             const result = await promotionsTransformer.init(createContext({ regionLocale: 'en_US' }));
             expect(result.activeProjects[0].title).to.equal('Summer Sale 2026');
+            expect(result.activeProjects[0].startDate).to.equal(START);
+            expect(result.activeProjects[0].endDate).to.equal(END);
         });
 
         it('ignores instant when not in preview mode', async () => {


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-202583
QA Checklist: https://wiki.corp.adobe.com/display/adobedotcom/M@S+Engineering+QA+Use+Cases

Please do the steps below before submitting your PR for a code review or QA

- [x] C1. Cover code with Unit Tests
- [ ] C2. Add a Nala test (double check with #fishbags if nala test is needed)
- [ ] C3. Verify all Checks are green (unit tests, nala tests)
- [ ] C4. PR description contains working Test Page link where the feature can be tested
- [ ] C5: you are ready to do a demo from Test Page in PR (bonus: write a working demo script that you'll use on Thursday, you can eventually put in your PR)
- [ ] C.6 read your Jira one more time to validate that you've addressed all AC's and nothing is missing



## Test URLs Preview:

- Before: https://main--da-cc--adobecom.aem.page/products/indesign?instant=2026-08-04T14:00:00.000Z&country=US 
- After: https://main--da-cc--adobecom.aem.page/products/indesign?instant=2026-08-04T14:00:00.000Z&country=US&maslibs=MWPW-202583&debug.io

## Test URLs Live:
- Before: https://main--da-cc--adobecom.aem.live/products/indesign?instant=2026-08-04T14:00:00.000Z&country=US
- After: https://main--da-cc--adobecom.aem.live/products/indesign?instant=2026-08-04T14:00:00.000Z&country=US&mas-io-url=https://14257-merchatscale-3ch023.adobeioruntime.net/api/v1/web/MerchAtScale

## Plans Preview (CCSN au promo is live)
- Before: https://main--cc--adobecom.aem.page/au/creativecloud/plans
- After: https://main--cc--adobecom.aem.page/au/creativecloud/plans?maslibs=MWPW-202583&debug.io


## Plans Live
- Before: https://main--cc--adobecom.aem.live/au/creativecloud/plans
- After: https://main--cc--adobecom.aem.live/au/creativecloud/plans?mas-io-url=https://14257-merchatscale-3ch023.adobeioruntime.net/api/v1/web/MerchAtScale